### PR TITLE
Fixed UE 5.3.1 compile errors and warnings

### DIFF
--- a/Plugins/Cog/Source/CogDebug/Public/CogDebugDrawHelper.h
+++ b/Plugins/Cog/Source/CogDebug/Public/CogDebugDrawHelper.h
@@ -2,7 +2,7 @@
 
 #include "CoreMinimal.h"
 
-namespace EDrawDebugTrace { enum Type; }
+namespace EDrawDebugTrace { enum Type : int; }
 
 class COGDEBUG_API FCogDebugDrawHelper
 {

--- a/Plugins/Cog/Source/CogWindow/Public/CogWindowWidgets.h
+++ b/Plugins/Cog/Source/CogWindow/Public/CogWindowWidgets.h
@@ -2,6 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "imgui.h"
+#include <GameFramework/PlayerInput.h>
 #include "UObject/ReflectedTypeAccessors.h"
 
 class UEnum;

--- a/Plugins/CogAI/Source/CogAI/Private/CogAIWindow_BehaviorTree.cpp
+++ b/Plugins/CogAI/Source/CogAI/Private/CogAIWindow_BehaviorTree.cpp
@@ -12,6 +12,7 @@
 #include "CogImguiHelper.h"
 #include "CogWindowWidgets.h"
 #include "GameFramework/Pawn.h"
+#include <Navigation/PathFollowingComponent.h>
 #include "imgui_internal.h"
 
 

--- a/Plugins/CogAbility/Source/CogAbility/Private/CogAbilityWindow_Abilities.cpp
+++ b/Plugins/CogAbility/Source/CogAbility/Private/CogAbilityWindow_Abilities.cpp
@@ -351,7 +351,12 @@ void FCogAbilityWindow_Abilities::RenderAbilitiesTable(UAbilitySystemComponent& 
 //--------------------------------------------------------------------------------------------------------------------------
 void FCogAbilityWindow_Abilities::RenderAbilityCooldown(const UAbilitySystemComponent& AbilitySystemComponent, UGameplayAbility& Ability)
 {
-    FGameplayAbilitySpec* Spec = Ability.GetCurrentAbilitySpec();
+	if (!Ability.IsInstantiated())
+	{
+		return;
+	}
+
+	FGameplayAbilitySpec* Spec = Ability.GetCurrentAbilitySpec();
 
     if (Spec == nullptr)
     {

--- a/Plugins/CogAbility/Source/CogAbility/Private/CogAbilityWindow_Abilities.cpp
+++ b/Plugins/CogAbility/Source/CogAbility/Private/CogAbilityWindow_Abilities.cpp
@@ -351,12 +351,7 @@ void FCogAbilityWindow_Abilities::RenderAbilitiesTable(UAbilitySystemComponent& 
 //--------------------------------------------------------------------------------------------------------------------------
 void FCogAbilityWindow_Abilities::RenderAbilityCooldown(const UAbilitySystemComponent& AbilitySystemComponent, UGameplayAbility& Ability)
 {
-	if (!Ability.IsInstantiated())
-	{
-		return;
-	}
-
-	FGameplayAbilitySpec* Spec = Ability.GetCurrentAbilitySpec();
+    FGameplayAbilitySpec* Spec = Ability.GetCurrentAbilitySpec();
 
     if (Spec == nullptr)
     {

--- a/Plugins/CogAbility/Source/CogAbility/Public/CogAbilityConfig_Alignment.h
+++ b/Plugins/CogAbility/Source/CogAbility/Public/CogAbilityConfig_Alignment.h
@@ -7,7 +7,7 @@
 class UAbilitySystemComponent;
 class UCogAbilityDataAsset;
 class UGameplayEffect;
-namespace EGameplayModOp { enum Type; };
+namespace EGameplayModOp { enum Type : int; };
 struct FGameplayAttribute;
 struct FGameplayModifierInfo;
 struct FModifierSpec;


### PR DESCRIPTION
Fixed compile errors for UE 5.3.1 and enum forward-declaration warnings.

Also, just FYI, I have not fixed these warnings, but there are two more warnings that are worth paying attention to:

1) warning C4996: 'UGameplayEffect::InheritableGameplayEffectTags': Inheritable Gameplay Effect Tags is deprecated. To configure, add a UAssetTagsGameplayEffectComponent. To access, use GetAssetTags. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.

2) warning C4996: 'FGameplayEffectSpec::StackCount': This member will be moved to private in the future. Use GetStackCount and SetStackCount. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.

This may become an issue in future UE releases.