### PR TITLE
Avoided ENSURE_ABILITY_IS_INSTANTIATED in GetCurrentAbilitySpec()

### DIFF
--- a/Plugins/Cog/Source/CogDebug/Public/CogDebugDrawHelper.h
+++ b/Plugins/Cog/Source/CogDebug/Public/CogDebugDrawHelper.h
@@ -2,7 +2,7 @@
 
 #include "CoreMinimal.h"
 
-namespace EDrawDebugTrace { enum Type; }
+namespace EDrawDebugTrace { enum Type : int; }
 
 class COGDEBUG_API FCogDebugDrawHelper
 {

--- a/Plugins/Cog/Source/CogWindow/Public/CogWindowWidgets.h
+++ b/Plugins/Cog/Source/CogWindow/Public/CogWindowWidgets.h
@@ -2,6 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "imgui.h"
+#include <GameFramework/PlayerInput.h>
 #include "UObject/ReflectedTypeAccessors.h"
 
 class UEnum;

--- a/Plugins/CogAI/Source/CogAI/Private/CogAIWindow_BehaviorTree.cpp
+++ b/Plugins/CogAI/Source/CogAI/Private/CogAIWindow_BehaviorTree.cpp
@@ -12,6 +12,7 @@
 #include "CogImguiHelper.h"
 #include "CogWindowWidgets.h"
 #include "GameFramework/Pawn.h"
+#include <Navigation/PathFollowingComponent.h>
 #include "imgui_internal.h"
 
 

--- a/Plugins/CogAbility/Source/CogAbility/Private/CogAbilityWindow_Abilities.cpp
+++ b/Plugins/CogAbility/Source/CogAbility/Private/CogAbilityWindow_Abilities.cpp
@@ -351,7 +351,12 @@ void FCogAbilityWindow_Abilities::RenderAbilitiesTable(UAbilitySystemComponent& 
 //--------------------------------------------------------------------------------------------------------------------------
 void FCogAbilityWindow_Abilities::RenderAbilityCooldown(const UAbilitySystemComponent& AbilitySystemComponent, UGameplayAbility& Ability)
 {
-    FGameplayAbilitySpec* Spec = Ability.GetCurrentAbilitySpec();
+	if (!Ability.IsInstantiated())
+	{
+		return;
+	}
+
+	FGameplayAbilitySpec* Spec = Ability.GetCurrentAbilitySpec();
 
     if (Spec == nullptr)
     {

--- a/Plugins/CogAbility/Source/CogAbility/Private/CogAbilityWindow_Abilities.cpp
+++ b/Plugins/CogAbility/Source/CogAbility/Private/CogAbilityWindow_Abilities.cpp
@@ -351,12 +351,7 @@ void FCogAbilityWindow_Abilities::RenderAbilitiesTable(UAbilitySystemComponent& 
 //--------------------------------------------------------------------------------------------------------------------------
 void FCogAbilityWindow_Abilities::RenderAbilityCooldown(const UAbilitySystemComponent& AbilitySystemComponent, UGameplayAbility& Ability)
 {
-	if (!Ability.IsInstantiated())
-	{
-		return;
-	}
-
-	FGameplayAbilitySpec* Spec = Ability.GetCurrentAbilitySpec();
+    FGameplayAbilitySpec* Spec = Ability.GetCurrentAbilitySpec();
 
     if (Spec == nullptr)
     {

--- a/Plugins/CogAbility/Source/CogAbility/Public/CogAbilityConfig_Alignment.h
+++ b/Plugins/CogAbility/Source/CogAbility/Public/CogAbilityConfig_Alignment.h
@@ -7,7 +7,7 @@
 class UAbilitySystemComponent;
 class UCogAbilityDataAsset;
 class UGameplayEffect;
-namespace EGameplayModOp { enum Type; };
+namespace EGameplayModOp { enum Type : int; };
 struct FGameplayAttribute;
 struct FGameplayModifierInfo;
 struct FModifierSpec;


### PR DESCRIPTION
At the start of the game, `ensure` is triggered, which is located in the `ENSURE_ABILITY_IS_INSTANTIATED` macro inside the `GetCurrentAbilitySpec()` function.
I don’t break the logic with my check, but I avoid triggering `ensure` every time