### PR TITLE
Avoided ENSURE_ABILITY_IS_INSTANTIATED in GetCurrentAbilitySpec()

### DIFF
--- a/Plugins/CogAbility/Source/CogAbility/Private/CogAbilityWindow_Abilities.cpp
+++ b/Plugins/CogAbility/Source/CogAbility/Private/CogAbilityWindow_Abilities.cpp
@@ -351,12 +351,12 @@ void FCogAbilityWindow_Abilities::RenderAbilitiesTable(UAbilitySystemComponent& 
 //--------------------------------------------------------------------------------------------------------------------------
 void FCogAbilityWindow_Abilities::RenderAbilityCooldown(const UAbilitySystemComponent& AbilitySystemComponent, UGameplayAbility& Ability)
 {
-	if (!Ability.IsInstantiated())
-	{
-		return;
-	}
+    if (!Ability.IsInstantiated())
+    {
+        return;
+    }
 
-	FGameplayAbilitySpec* Spec = Ability.GetCurrentAbilitySpec();
+    FGameplayAbilitySpec* Spec = Ability.GetCurrentAbilitySpec();
 
     if (Spec == nullptr)
     {

--- a/Plugins/CogAbility/Source/CogAbility/Private/CogAbilityWindow_Abilities.cpp
+++ b/Plugins/CogAbility/Source/CogAbility/Private/CogAbilityWindow_Abilities.cpp
@@ -351,7 +351,12 @@ void FCogAbilityWindow_Abilities::RenderAbilitiesTable(UAbilitySystemComponent& 
 //--------------------------------------------------------------------------------------------------------------------------
 void FCogAbilityWindow_Abilities::RenderAbilityCooldown(const UAbilitySystemComponent& AbilitySystemComponent, UGameplayAbility& Ability)
 {
-    FGameplayAbilitySpec* Spec = Ability.GetCurrentAbilitySpec();
+	if (!Ability.IsInstantiated())
+	{
+		return;
+	}
+
+	FGameplayAbilitySpec* Spec = Ability.GetCurrentAbilitySpec();
 
     if (Spec == nullptr)
     {


### PR DESCRIPTION
At the start of the game, `ensure` is triggered, which is located in the `ENSURE_ABILITY_IS_INSTANTIATED` macro inside the `GetCurrentAbilitySpec()` function.

I don’t break the logic with my check, but I avoid triggering `ensure` every time