### PR TITLE
[Suggestion] Set the Enabled Input to false by default.

### DIFF
--- a/Plugins/Cog/Source/CogImgui/Public/CogImguiModule.h
+++ b/Plugins/Cog/Source/CogImgui/Public/CogImguiModule.h
@@ -45,7 +45,7 @@ private:
 
     ImFontAtlas DefaultFontAtlas;
 
-    bool bEnabledInput = true;
+    bool bEnabledInput = false;
 
     bool bIsInitialized = false;
 };


### PR DESCRIPTION
Simply set Enabled Input to false by default. When debug windows are active by default, enabling the game can lead to confusion about "what's wrong with the game controls". I believe that if input is needed in debug windows, it should be activated manually.