### PR TITLE
Fix possible crash when GetPlayerInput() is nullptr on startup

### DIFF
--- a/Plugins/CogInput/Source/CogInput/Private/CogInputWindow_Actions.cpp
+++ b/Plugins/CogInput/Source/CogInput/Private/CogInputWindow_Actions.cpp
@@ -239,4 +239,4 @@ void FCogInputWindow_Actions::DrawAxis(const char* Format, const char* ActionNam
     ImGui::SetNextItemWidth(-1);
     FCogWindowWidgets::SliderWithReset("##Inject", InjectValue, -1.0f, 1.0f, 0.0f, "%0.2f");
     ImGui::PopID();
-} 
+}

--- a/Plugins/CogInput/Source/CogInput/Private/CogInputWindow_Actions.cpp
+++ b/Plugins/CogInput/Source/CogInput/Private/CogInputWindow_Actions.cpp
@@ -66,10 +66,10 @@ void FCogInputWindow_Actions::RenderContent()
     }
 
     if(EnhancedInputSubsystem->GetPlayerInput() == nullptr)
-	{
-		ImGui::Text("No Player Input");
-		return;
-	}
+    {
+        ImGui::Text("No Player Input");
+        return;
+    }
     
     if (ImGui::BeginMenuBar())
     {

--- a/Plugins/CogInput/Source/CogInput/Private/CogInputWindow_Actions.cpp
+++ b/Plugins/CogInput/Source/CogInput/Private/CogInputWindow_Actions.cpp
@@ -239,4 +239,4 @@ void FCogInputWindow_Actions::DrawAxis(const char* Format, const char* ActionNam
     ImGui::SetNextItemWidth(-1);
     FCogWindowWidgets::SliderWithReset("##Inject", InjectValue, -1.0f, 1.0f, 0.0f, "%0.2f");
     ImGui::PopID();
-}
+} 

--- a/Plugins/CogInput/Source/CogInput/Private/CogInputWindow_Actions.cpp
+++ b/Plugins/CogInput/Source/CogInput/Private/CogInputWindow_Actions.cpp
@@ -64,6 +64,12 @@ void FCogInputWindow_Actions::RenderContent()
         ImGui::Text("No Enhanced Input Subsystem");
         return;
     }
+
+    if(EnhancedInputSubsystem->GetPlayerInput() == nullptr)
+	{
+		ImGui::Text("No Player Input");
+		return;
+	}
     
     if (ImGui::BeginMenuBar())
     {


### PR DESCRIPTION
If cog is enabled on startup and player init delayed because of gameplay reasons then this case can happen.