### PR TITLE
Updated to 5.3.x, renamed interface function, and more

### DIFF
--- a/Cog.uproject
+++ b/Cog.uproject
@@ -1,29 +1,26 @@
 {
-    "FileVersion": 3,
-    "EngineAssociation": "5.1",
-    "Category": "",
-    "Description": "",
-    "Modules":
-    [
-        {
-            "Name": "CogSample",
-            "Type": "Runtime",
-            "LoadingPhase": "Default"
-        }
-    ],
-    "Plugins":
-    [
-        {
-            "Name": "GameplayAbilities",
-            "Enabled": true
-        },
-        {
-            "Name": "ModelingToolsEditorMode",
-            "Enabled": true,
-            "TargetAllowList":
-            [
-                "Editor"
-            ]
-        }
-    ]
+	"FileVersion": 3,
+	"EngineAssociation": "5.3",
+	"Category": "",
+	"Description": "",
+	"Modules": [
+		{
+			"Name": "CogSample",
+			"Type": "Runtime",
+			"LoadingPhase": "Default"
+		}
+	],
+	"Plugins": [
+		{
+			"Name": "GameplayAbilities",
+			"Enabled": true
+		},
+		{
+			"Name": "ModelingToolsEditorMode",
+			"Enabled": true,
+			"TargetAllowList": [
+				"Editor"
+			]
+		}
+	]
 }

--- a/Plugins/Cog/Source/CogDebug/Private/CogDebugGizmo.cpp
+++ b/Plugins/Cog/Source/CogDebug/Private/CogDebugGizmo.cpp
@@ -2,7 +2,7 @@
 
 #include "CogDebug.h"
 #include "CogDebugDrawHelper.h"
-#include "CogImGuiHelper.h"
+#include "CogImguiHelper.h"
 #include "Components/PrimitiveComponent.h"
 #include "Components/SceneComponent.h"
 #include "DrawDebugHelpers.h"

--- a/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_CollisionTester.cpp
+++ b/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_CollisionTester.cpp
@@ -1,7 +1,7 @@
 #include "CogEngineWindow_CollisionTester.h"
 
 #include "CogDebug.h"
-#include "CogImGuiHelper.h"
+#include "CogImguiHelper.h"
 #include "CogWindowWidgets.h"
 #include "Components/PrimitiveComponent.h"
 #include "Components/SceneComponent.h"

--- a/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_DebugSettings.cpp
+++ b/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_DebugSettings.cpp
@@ -1,7 +1,7 @@
 #include "CogEngineWindow_DebugSettings.h"
 
 #include "CogDebug.h"
-#include "CogImGuiHelper.h"
+#include "CogImguiHelper.h"
 #include "CogWindowWidgets.h"
 #include "Engine/CollisionProfile.h"
 

--- a/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Transform.cpp
+++ b/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Transform.cpp
@@ -1,7 +1,7 @@
 #include "CogEngineWindow_Transform.h"
 
 #include "CogDebug.h"
-#include "CogImGuiHelper.h"
+#include "CogImguiHelper.h"
 #include "CogWindowWidgets.h"
 #include "GameFramework/Actor.h"
 #include "imgui.h"

--- a/Source/CogSample.Target.cs
+++ b/Source/CogSample.Target.cs
@@ -7,7 +7,7 @@ public class CogSampleTarget : TargetRules
 	{
 		Type = TargetType.Game;
 		DefaultBuildSettings = BuildSettingsVersion.V2;
-		IncludeOrderVersion = EngineIncludeOrderVersion.Unreal5_1;
+		IncludeOrderVersion = EngineIncludeOrderVersion.Unreal5_2;
 		ExtraModuleNames.Add("CogSample");
         //bUseUnityBuild = false;
         //bUsePCHFiles = false;

--- a/Source/CogSample/CogSampleCharacter.cpp
+++ b/Source/CogSample/CogSampleCharacter.cpp
@@ -827,7 +827,7 @@ void ACogSampleCharacter::UpdateActiveAbilitySlots()
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-FVector ACogSampleCharacter::GetTargetLocation() const
+FVector ACogSampleCharacter::GetTargetActorLocation() const
 {
     return GetActorLocation();
 }

--- a/Source/CogSample/CogSampleCharacter.h
+++ b/Source/CogSample/CogSampleCharacter.h
@@ -134,7 +134,7 @@ public:
     // ICogSampleTargetInterface overrides
     //----------------------------------------------------------------------------------------------------------------------
     
-    virtual FVector GetTargetLocation() const override;
+    virtual FVector GetTargetActorLocation() const override;
 
     virtual void GetTargetCapsules(TArray<const UCapsuleComponent*>& Capsules) const override;
 

--- a/Source/CogSample/CogSampleFunctionLibrary_Gameplay.cpp
+++ b/Source/CogSample/CogSampleFunctionLibrary_Gameplay.cpp
@@ -154,7 +154,7 @@ FVector UCogSampleFunctionLibrary_Gameplay::GetActorTargetLocation(const AActor*
 
     if (const ICogSampleTargetableInterface* Targetable = Cast<ICogSampleTargetableInterface>(Actor))
     {
-        return Targetable->GetTargetLocation();
+        return Targetable->GetTargetActorLocation();
     }
 
     return Actor->GetActorLocation();

--- a/Source/CogSample/CogSampleSpawnPredictionComponent.cpp
+++ b/Source/CogSample/CogSampleSpawnPredictionComponent.cpp
@@ -296,10 +296,10 @@ FColor UCogSampleSpawnPredictionComponent::GetRoleColor() const
 {
     switch (Role)
     {
-        case ECogSampleSpawnPredictionRole::Server:     return FColor::FColor(255,   0,   0, 255);
-        case ECogSampleSpawnPredictionRole::Predicted:  return FColor::FColor(255, 255,   0, 255);
-        case ECogSampleSpawnPredictionRole::Replicated: return FColor::FColor(128, 128,   0, 255);
-        case ECogSampleSpawnPredictionRole::Remote:     return FColor::FColor(255,   0, 255, 255);
+        case ECogSampleSpawnPredictionRole::Server:     return FColor(255,   0,   0, 255);
+        case ECogSampleSpawnPredictionRole::Predicted:  return FColor(255, 255,   0, 255);
+        case ECogSampleSpawnPredictionRole::Replicated: return FColor(128, 128,   0, 255);
+        case ECogSampleSpawnPredictionRole::Remote:     return FColor(255,   0, 255, 255);
     }
 
     return FColor(128, 128, 128, 255);

--- a/Source/CogSample/CogSampleTargetableInterface.h
+++ b/Source/CogSample/CogSampleTargetableInterface.h
@@ -18,7 +18,7 @@ class ICogSampleTargetableInterface
 
 public:
 
-    virtual FVector GetTargetLocation() const { return FVector::ZeroVector; }
+    virtual FVector GetTargetActorLocation() const { return FVector::ZeroVector; }
 
     virtual void GetTargetCapsules(TArray<const UCapsuleComponent*>& Capsules) const { }
 };

--- a/Source/CogSampleEditor.Target.cs
+++ b/Source/CogSampleEditor.Target.cs
@@ -7,7 +7,7 @@ public class CogSampleEditorTarget : TargetRules
 	{
 		Type = TargetType.Editor;
 		DefaultBuildSettings = BuildSettingsVersion.V2;
-		IncludeOrderVersion = EngineIncludeOrderVersion.Unreal5_1;
+		IncludeOrderVersion = EngineIncludeOrderVersion.Unreal5_2;
 		ExtraModuleNames.Add("CogSample");
 	}
 }


### PR DESCRIPTION
Addresses #29 

In CogSampleSpawnPredictionComponent.cpp, lines 299 through 302 have return statements of FColor::FColor, these have been updated to a single FColor return statement In CogSampleTargetableInterface.h, the GetTargetLocation function does not compile against Linux. Reason being that it interferes with built in functions that share the same name (notably within the AIController class). This has been changed to GetTargetActorLocation to maintain a similar name. Recommend adding comments when possible.

Additionaly, the sample project and the editor have had their IncludeOrderVersion updated to 5.2. This was done to clear the warning listing that 5.1 will be deprecated in the next major version release.

The project compiles against Windows and Linux (likely other platforms too, unable to check) 
Happy to help! :)