### PR TITLE
Use TCHAR_TO_UTF8 in Inspector window for some properties

### DIFF
--- a/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Inspector.cpp
+++ b/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Inspector.cpp
@@ -349,7 +349,7 @@ bool FCogEngineWindow_Inspector::RenderInspector()
                 ImGui::SetNextItemOpen(false);
             }
 
-            if (ImGui::CollapsingHeader(TCHAR_TO_ANSI(*Entry.Key), nullptr, ImGuiTreeNodeFlags_DefaultOpen))
+            if (ImGui::CollapsingHeader(TCHAR_TO_UTF8(*Entry.Key), nullptr, ImGuiTreeNodeFlags_DefaultOpen))
             {
                 if (RenderBegin())
                 {
@@ -510,7 +510,7 @@ bool FCogEngineWindow_Inspector::RenderProperty(const FProperty* Property, uint8
             ImGui::TableNextColumn();
             ImGui::Text("DisplayName:");
             ImGui::TableNextColumn();
-            ImGui::Text(TCHAR_TO_ANSI(*Property->GetDisplayNameText().ToString()));
+            ImGui::Text(TCHAR_TO_UTF8(*Property->GetDisplayNameText().ToString()));
 #endif  // WITH_EDITORONLY_DATA
 
             ImGui::TableNextRow();
@@ -532,7 +532,7 @@ bool FCogEngineWindow_Inspector::RenderProperty(const FProperty* Property, uint8
             ImGui::TableNextColumn();
             if (Property->HasMetaData("Tooltip"))
             {
-                ImGui::Text(TCHAR_TO_ANSI(*Property->GetToolTipText(false).ToString()));
+                ImGui::Text(TCHAR_TO_UTF8(*Property->GetToolTipText(false).ToString()));
             }
 #endif  // WITH_EDITORONLY_DATA
 
@@ -550,7 +550,7 @@ bool FCogEngineWindow_Inspector::RenderProperty(const FProperty* Property, uint8
             ImGui::BeginTooltip();
             ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
 
-            ImGui::Text(TCHAR_TO_ANSI(*Property->GetToolTipText(false).ToString()));
+            ImGui::Text(TCHAR_TO_UTF8(*Property->GetToolTipText(false).ToString()));
             ImGui::Text("Details [CTRL]");
             ImGui::PopTextWrapPos();
             ImGui::EndTooltip();
@@ -819,7 +819,7 @@ bool FCogEngineWindow_Inspector::RenderText(const FTextProperty* TextProperty, u
     FString Text;
     TextProperty->ExportTextItem_Direct(Text, PointerToValue, nullptr, nullptr, PPF_None, nullptr);
     ImGui::BeginDisabled();
-    ImGui::Text("%s", TCHAR_TO_ANSI(*Text));
+    ImGui::Text("%s", TCHAR_TO_UTF8(*Text));
     ImGui::EndDisabled();
 
     return false;


### PR DESCRIPTION
When using accents in `FText` properties, tooltips or display names, `TCHAR_TO_ANSI()` garbles the rendering. This small PR fixes that by using `TCHAR_TO_UTF8()` where appropriate instead.