### PR TITLE
Fix typo in Show Borders

### DIFF
--- a/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Inspector.cpp
+++ b/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Inspector.cpp
@@ -273,7 +273,7 @@ void FCogEngineWindow_Inspector::RenderMenu()
 
             ImGui::Checkbox("Sort by Name", &Config->bSortByName);
             ImGui::Checkbox("Show Background", &Config->bShowRowBackground);
-            ImGui::Checkbox("Show Sorders", &Config->bShowBorders);
+            ImGui::Checkbox("Show Borders", &Config->bShowBorders);
 #if WITH_EDITORONLY_DATA
             ImGui::Checkbox("Show Display Name", &Config->bShowDisplayName);
             ImGui::Checkbox("Show Categories", &Config->bShowCategories);

--- a/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Inspector.cpp
+++ b/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Inspector.cpp
@@ -172,15 +172,10 @@ void FCogEngineWindow_Inspector::RenderMenu()
             }
             if (ImGui::IsItemHovered())
             {
-                ImGui::SetTooltip("Current Inspected Object: %s", InspectedObjectName.Get());
+                ImGui::SetTooltip("%s", InspectedObjectName.Get());
             }
 
             ImGui::PopStyleVar(1);
-        }
-
-        if (ImGui::IsItemHovered())
-        {
-            ImGui::SetTooltip("%s", InspectedObjectName.Get());
         }
 
         ImGui::PopStyleColor(1);


### PR DESCRIPTION
Instead of **Show Borders**, the label was **Show Sorders**. Also, the tooltip for the inspected object in the Inspector panel was set twice, so I changed it to only be set once.