### PR TITLE
Fix building with NO_LOGGING enabled in non-shipping

### DIFF
--- a/Plugins/Cog/Source/Cog/Private/CogWidgets.cpp
+++ b/Plugins/Cog/Source/Cog/Private/CogWidgets.cpp
@@ -5,7 +5,6 @@
 #include "CogImguiHelper.h"
 #include "CogImguiInputHelper.h"
 #include "CogHelper.h"
-#include "Editor.h"
 #include "Components/PrimitiveComponent.h"
 #include "EngineUtils.h"
 #include "imgui.h"
@@ -16,6 +15,7 @@
 #include "InputCoreTypes.h"
 
 #if WITH_EDITOR
+#include "Editor.h"
 #include "IAssetTools.h"
 #include "Subsystems/AssetEditorSubsystem.h"
 #endif

--- a/Plugins/Cog/Source/CogCommon/CogCommon.Build.cs
+++ b/Plugins/Cog/Source/CogCommon/CogCommon.Build.cs
@@ -18,11 +18,17 @@ public class CogCommon : ModuleRules
 			}
 			);
 			
+		PublicIncludePathModuleNames.AddRange(
+			new string[]
+			{
+				"CogDebug"
+			}
+			);
 		
 		PublicDependencyModuleNames.AddRange(
 			new string[]
 			{
-				"Core",
+				"Core"
 			}
             );
 			

--- a/Plugins/Cog/Source/CogCommon/Public/CogCommon.h
+++ b/Plugins/Cog/Source/CogCommon/Public/CogCommon.h
@@ -10,11 +10,24 @@
 #endif
 
 #if ENABLE_COG
-
 #include "CogDebug.h"
+#define IF_COG(expr) { expr; }
+#else
+#define IF_COG(expr) (0)
+#endif
 
-#define IF_COG(expr)            { expr; }
-#define COG_LOG_CATEGORY        FLogCategoryBase
+// In no logging configurations all log categories are of type FNoLoggingCategory, which has no relation with
+// FLogCategoryBase. In order to not need to conditionally set the argument alias the type here.
+#if NO_LOGGING
+typedef FNoLoggingCategory FCogLogCategoryAlias;
+#else
+typedef FLogCategoryBase FCogLogCategoryAlias;
+#endif
+
+/**
+ * Logging Macros
+ */
+#if ENABLE_COG && !NO_LOGGING
 
 //--------------------------------------------------------------------------------------------------------------------------
 #define COG_LOG_ACTIVE_FOR_OBJECT(Object)   (FCogDebug::IsDebugActiveForObject(Object))
@@ -81,11 +94,7 @@
         COG_LOG(LogCategory, Verbosity, TEXT("%s | %s"), *GetNameSafe(Object), *FString::Printf(Format, ##__VA_ARGS__));    \
     }                                                                                                                       \
 
-#else //ENABLE_COG
-
-#define IF_COG(expr)                                                            (0)
-#define COG_LOG_CATEGORY                                                        FNoLoggingCategory
-#define COG_LOG_ABILITY(...)                                                    (0)
+#else //ENABLE_COG && !NO_LOGGING
 #define COG_NOTIFY(Format, ...)                                                 (0)
 #define COG_NOTIFY_WARNING(Format, ...)                                         (0)
 #define COG_NOTIFY_ERROR(Format, ...)                                           (0)
@@ -95,6 +104,5 @@
 #define COG_LOG_FUNC(LogCategory, Verbosity, Format, ...)                       (0)
 #define COG_LOG_OBJECT(LogCategory, Verbosity, Actor, Format, ...)              (0)
 #define COG_LOG_OBJECT_NO_CONTEXT(LogCategory, Verbosity, Actor, Format, ...)   (0)
-
-#endif //ENABLE_COG
+#endif //ENABLE_COG && !NO_LOGGING
 

--- a/Plugins/Cog/Source/CogCommon/Public/CogCommonLog.h
+++ b/Plugins/Cog/Source/CogCommon/Public/CogCommonLog.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "CogCommon.h"
 #include "CogCommonLog.generated.h"
 
 //--------------------------------------------------------------------------------------------------------------------------
@@ -30,5 +31,5 @@ struct COGCOMMON_API FCogLogCategory
 
     FString GetName() const { return Name.ToString(); }
 
-    mutable FLogCategoryBase* LogCategory = nullptr;
+    mutable FCogLogCategoryAlias* LogCategory = nullptr;
 };

--- a/Plugins/Cog/Source/CogDebug/Private/CogDebugDraw.cpp
+++ b/Plugins/Cog/Source/CogDebug/Private/CogDebugDraw.cpp
@@ -19,7 +19,7 @@
 #if ENABLE_COG
 
 //--------------------------------------------------------------------------------------------------------------------------
-void FCogDebugDraw::String2D(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FString& Text, const FVector2D& Location, const FColor& Color, const bool Persistent)
+void FCogDebugDraw::String2D(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FString& Text, const FVector2D& Location, const FColor& Color, const bool Persistent)
 {
     if (FCogDebugLog::IsLogCategoryActive(LogCategory) == false)
     {
@@ -36,7 +36,7 @@ void FCogDebugDraw::String2D(const FLogCategoryBase& LogCategory, const UObject*
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-void FCogDebugDraw::Segment2D(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FVector2D& SegmentStart, const FVector2D& SegmentEnd, const FColor& Color, const bool Persistent)
+void FCogDebugDraw::Segment2D(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FVector2D& SegmentStart, const FVector2D& SegmentEnd, const FColor& Color, const bool Persistent)
 {
     if (FCogDebugLog::IsLogCategoryActive(LogCategory) == false)
     {
@@ -53,7 +53,7 @@ void FCogDebugDraw::Segment2D(const FLogCategoryBase& LogCategory, const UObject
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-void FCogDebugDraw::Circle2D(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FVector2D& Location, const float Radius, const FColor& Color, const bool Persistent)
+void FCogDebugDraw::Circle2D(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FVector2D& Location, const float Radius, const FColor& Color, const bool Persistent)
 {
     if (FCogDebugLog::IsLogCategoryActive(LogCategory) == false)
     {
@@ -72,7 +72,7 @@ void FCogDebugDraw::Circle2D(const FLogCategoryBase& LogCategory, const UObject*
 
 //--------------------------------------------------------------------------------------------------------------------------
 
-void FCogDebugDraw::Rect2D(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FVector2D& Min, const FVector2D& Max, const FColor& Color, const bool Persistent)
+void FCogDebugDraw::Rect2D(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FVector2D& Min, const FVector2D& Max, const FColor& Color, const bool Persistent)
 {
     if (FCogDebugLog::IsLogCategoryActive(LogCategory) == false)
     {
@@ -90,7 +90,7 @@ void FCogDebugDraw::Rect2D(const FLogCategoryBase& LogCategory, const UObject* W
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-void FCogDebugDraw::String(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FString& Text, const FVector& Location, const FColor& Color, const bool Persistent)
+void FCogDebugDraw::String(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FString& Text, const FVector& Location, const FColor& Color, const bool Persistent)
 {
     if (FCogDebugLog::IsLogCategoryActive(LogCategory) == false)
     {
@@ -118,7 +118,7 @@ void FCogDebugDraw::String(const FLogCategoryBase& LogCategory, const UObject* W
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-void FCogDebugDraw::Point(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FVector& Location, const float Size, const FColor& Color, const bool Persistent, const uint8 DepthPriority)
+void FCogDebugDraw::Point(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FVector& Location, const float Size, const FColor& Color, const bool Persistent, const uint8 DepthPriority)
 {
     if (FCogDebugLog::IsLogCategoryActive(LogCategory) == false)
     {
@@ -145,7 +145,7 @@ void FCogDebugDraw::Point(const FLogCategoryBase& LogCategory, const UObject* Wo
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-void FCogDebugDraw::Segment(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FVector& SegmentStart, const FVector& SegmentEnd, const FColor& Color, const bool Persistent, const uint8 DepthPriority)
+void FCogDebugDraw::Segment(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FVector& SegmentStart, const FVector& SegmentEnd, const FColor& Color, const bool Persistent, const uint8 DepthPriority)
 {
     if (FCogDebugLog::IsLogCategoryActive(LogCategory) == false)
     {
@@ -175,7 +175,7 @@ void FCogDebugDraw::Segment(const FLogCategoryBase& LogCategory, const UObject* 
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-void FCogDebugDraw::Bone(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FVector& BoneLocation, const FVector& ParentLocation, const FColor& Color, const bool Persistent, const uint8 DepthPriority)
+void FCogDebugDraw::Bone(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FVector& BoneLocation, const FVector& ParentLocation, const FColor& Color, const bool Persistent, const uint8 DepthPriority)
 {
     if (FCogDebugLog::IsLogCategoryActive(LogCategory) == false)
     {
@@ -214,7 +214,7 @@ void FCogDebugDraw::Bone(const FLogCategoryBase& LogCategory, const UObject* Wor
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-void FCogDebugDraw::Arrow(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FVector& SegmentStart, const FVector& SegmentEnd, const FColor& Color, const bool Persistent, const uint8 DepthPriority)
+void FCogDebugDraw::Arrow(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FVector& SegmentStart, const FVector& SegmentEnd, const FColor& Color, const bool Persistent, const uint8 DepthPriority)
 {
     if (FCogDebugLog::IsLogCategoryActive(LogCategory) == false)
     {
@@ -245,7 +245,7 @@ void FCogDebugDraw::Arrow(const FLogCategoryBase& LogCategory, const UObject* Wo
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-void FCogDebugDraw::Axis(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FVector& AxisLoc, const FRotator& AxisRot, const float Scale, const bool Persistent, const uint8 DepthPriority)
+void FCogDebugDraw::Axis(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FVector& AxisLoc, const FRotator& AxisRot, const float Scale, const bool Persistent, const uint8 DepthPriority)
 {
     if (FCogDebugLog::IsLogCategoryActive(LogCategory) == false)
     {
@@ -277,7 +277,7 @@ void FCogDebugDraw::Axis(const FLogCategoryBase& LogCategory, const UObject* Wor
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-void FCogDebugDraw::Circle(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FMatrix& Matrix, float Radius, const FColor& Color, const bool Persistent, const uint8 DepthPriority)
+void FCogDebugDraw::Circle(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FMatrix& Matrix, float Radius, const FColor& Color, const bool Persistent, const uint8 DepthPriority)
 {
     if (FCogDebugLog::IsLogCategoryActive(LogCategory) == false)
     {
@@ -311,7 +311,7 @@ void FCogDebugDraw::Circle(const FLogCategoryBase& LogCategory, const UObject* W
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-void FCogDebugDraw::CircleArc(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FMatrix& Matrix, const float InnerRadius, const float OuterRadius, const float Angle, const FColor& Color, const bool Persistent, const uint8 DepthPriority)
+void FCogDebugDraw::CircleArc(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FMatrix& Matrix, const float InnerRadius, const float OuterRadius, const float Angle, const FColor& Color, const bool Persistent, const uint8 DepthPriority)
 {
     if (FCogDebugLog::IsLogCategoryActive(LogCategory) == false)
     {
@@ -345,7 +345,7 @@ void FCogDebugDraw::CircleArc(const FLogCategoryBase& LogCategory, const UObject
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-void FCogDebugDraw::FlatCapsule(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FVector2D& Start, const FVector2D& End, const float Radius, const float Z, const FColor& Color, const bool Persistent, const uint8 DepthPriority)
+void FCogDebugDraw::FlatCapsule(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FVector2D& Start, const FVector2D& End, const float Radius, const float Z, const FColor& Color, const bool Persistent, const uint8 DepthPriority)
 {
     if (FCogDebugLog::IsLogCategoryActive(LogCategory) == false)
     {
@@ -378,7 +378,7 @@ void FCogDebugDraw::FlatCapsule(const FLogCategoryBase& LogCategory, const UObje
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-void FCogDebugDraw::Sphere(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FVector& Location, const float Radius, const FColor& Color, const bool Persistent, const uint8 DepthPriority)
+void FCogDebugDraw::Sphere(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FVector& Location, const float Radius, const FColor& Color, const bool Persistent, const uint8 DepthPriority)
 {
     if (FCogDebugLog::IsLogCategoryActive(LogCategory) == false)
     {
@@ -409,7 +409,7 @@ void FCogDebugDraw::Sphere(const FLogCategoryBase& LogCategory, const UObject* W
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-void FCogDebugDraw::Box(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FVector& Center, const FVector& Extent, const FQuat& Rotation, const FColor& Color, const bool Persistent, const uint8 DepthPriority)
+void FCogDebugDraw::Box(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FVector& Center, const FVector& Extent, const FQuat& Rotation, const FColor& Color, const bool Persistent, const uint8 DepthPriority)
 {
     if (FCogDebugLog::IsLogCategoryActive(LogCategory) == false)
     {
@@ -440,7 +440,7 @@ void FCogDebugDraw::Box(const FLogCategoryBase& LogCategory, const UObject* Worl
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-void FCogDebugDraw::SolidBox(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FVector& Center, const FVector& Extent, const FQuat& Rotation, const FColor& Color, const bool Persistent, const uint8 DepthPriority)
+void FCogDebugDraw::SolidBox(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FVector& Center, const FVector& Extent, const FQuat& Rotation, const FColor& Color, const bool Persistent, const uint8 DepthPriority)
 {
     if (FCogDebugLog::IsLogCategoryActive(LogCategory) == false)
     {
@@ -475,7 +475,7 @@ void FCogDebugDraw::SolidBox(const FLogCategoryBase& LogCategory, const UObject*
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-void FCogDebugDraw::Frustum(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FMatrix& Matrix, const float Angle, const float AspectRatio, const float NearPlane, const float FarPlane, const FColor& Color, const bool Persistent, const uint8 DepthPriority)
+void FCogDebugDraw::Frustum(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FMatrix& Matrix, const float Angle, const float AspectRatio, const float NearPlane, const float FarPlane, const FColor& Color, const bool Persistent, const uint8 DepthPriority)
 {
     if (FCogDebugLog::IsLogCategoryActive(LogCategory) == false)
     {
@@ -507,7 +507,7 @@ void FCogDebugDraw::Frustum(const FLogCategoryBase& LogCategory, const UObject* 
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-void FCogDebugDraw::Capsule(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FVector& Center, const float HalfHeight, const float Radius, const FQuat& Rotation, const FColor& Color, const bool Persistent, const uint8 DepthPriority)
+void FCogDebugDraw::Capsule(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FVector& Center, const float HalfHeight, const float Radius, const FQuat& Rotation, const FColor& Color, const bool Persistent, const uint8 DepthPriority)
 {
     if (FCogDebugLog::IsLogCategoryActive(LogCategory) == false)
     {
@@ -539,7 +539,7 @@ void FCogDebugDraw::Capsule(const FLogCategoryBase& LogCategory, const UObject* 
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-void FCogDebugDraw::Points(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const TArray<FVector>& Points, const float Radius, const FColor& StartColor, const FColor& EndColor, const bool Persistent, const uint8 DepthPriority)
+void FCogDebugDraw::Points(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const TArray<FVector>& Points, const float Radius, const FColor& StartColor, const FColor& EndColor, const bool Persistent, const uint8 DepthPriority)
 {
     if (FCogDebugLog::IsLogCategoryActive(LogCategory))
     {
@@ -554,7 +554,7 @@ void FCogDebugDraw::Points(const FLogCategoryBase& LogCategory, const UObject* W
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-void FCogDebugDraw::Path(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const TArray<FVector>& Points, const float PointSize, const FColor& StartColor, const FColor& EndColor, const bool Persistent, const uint8 DepthPriority)
+void FCogDebugDraw::Path(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const TArray<FVector>& Points, const float PointSize, const FColor& StartColor, const FColor& EndColor, const bool Persistent, const uint8 DepthPriority)
 {
     if (FCogDebugLog::IsLogCategoryActive(LogCategory) == false)
     {
@@ -593,7 +593,7 @@ void FCogDebugDraw::Path(const FLogCategoryBase& LogCategory, const UObject* Wor
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-void FCogDebugDraw::Skeleton(const FLogCategoryBase& LogCategory, const USkeletalMeshComponent* Skeleton, const FColor& Color, const bool DrawSecondaryBones, const uint8 DepthPriority)
+void FCogDebugDraw::Skeleton(const FCogLogCategoryAlias& LogCategory, const USkeletalMeshComponent* Skeleton, const FColor& Color, const bool DrawSecondaryBones, const uint8 DepthPriority)
 {
     if (Skeleton == nullptr)
     {
@@ -639,7 +639,7 @@ void FCogDebugDraw::Skeleton(const FLogCategoryBase& LogCategory, const USkeleta
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-void FCogDebugDraw::LineTrace(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FVector& Start, const FVector& End, const bool HasHits, TArray<FHitResult>& HitResults, const FCogDebugDrawLineTraceParams& Settings)
+void FCogDebugDraw::LineTrace(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FVector& Start, const FVector& End, const bool HasHits, TArray<FHitResult>& HitResults, const FCogDebugDrawLineTraceParams& Settings)
 {
     if (FCogDebugLog::IsLogCategoryActive(LogCategory) == false)
     { return; }
@@ -666,7 +666,7 @@ void FCogDebugDraw::LineTrace(const FLogCategoryBase& LogCategory, const UObject
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-void FCogDebugDraw::Sweep(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FCollisionShape& Shape, const FVector& Start, const FVector& End, const FQuat& Rotation, const bool HasHits, TArray<FHitResult>& HitResults, const FCogDebugDrawSweepParams& Settings)
+void FCogDebugDraw::Sweep(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FCollisionShape& Shape, const FVector& Start, const FVector& End, const FQuat& Rotation, const bool HasHits, TArray<FHitResult>& HitResults, const FCogDebugDrawSweepParams& Settings)
 {
     if (FCogDebugLog::IsLogCategoryActive(LogCategory) == false)
     { return; }
@@ -702,7 +702,7 @@ void FCogDebugDraw::Sweep(const FLogCategoryBase& LogCategory, const UObject* Wo
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-void FCogDebugDraw::Overlap(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FCollisionShape& Shape, const FVector& Location, const FQuat& Rotation, const bool HasHits, TArray<FOverlapResult>& OverlapResults, const FCogDebugDrawOverlapParams& Settings)
+void FCogDebugDraw::Overlap(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FCollisionShape& Shape, const FVector& Location, const FQuat& Rotation, const bool HasHits, TArray<FOverlapResult>& OverlapResults, const FCogDebugDrawOverlapParams& Settings)
 {
     if (FCogDebugLog::IsLogCategoryActive(LogCategory) == false)
     { return; }

--- a/Plugins/Cog/Source/CogDebug/Private/CogDebugDrawBlueprint.cpp
+++ b/Plugins/Cog/Source/CogDebug/Private/CogDebugDrawBlueprint.cpp
@@ -8,7 +8,7 @@
 void UCogDebugDrawBlueprint::DebugDrawString(const UObject* WorldContextObject, const FCogLogCategory LogCategory, const FString& Text, const FVector Location, const FLinearColor Color, const bool Persistent)
 {
 #if ENABLE_COG
-    if (const FLogCategoryBase* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
+    if (const FCogLogCategoryAlias* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
     {
         FCogDebugDraw::String(*LogCategoryPtr, WorldContextObject, Text, Location, Color.ToFColor(true), Persistent);
     }
@@ -19,7 +19,7 @@ void UCogDebugDrawBlueprint::DebugDrawString(const UObject* WorldContextObject, 
 void UCogDebugDrawBlueprint::DebugDrawPoint(const UObject* WorldContextObject, const FCogLogCategory LogCategory, const FVector Location, const float Size, const FLinearColor Color, const bool Persistent, const uint8 DepthPriority)
 {
 #if ENABLE_COG
-    if (const FLogCategoryBase* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
+    if (const FCogLogCategoryAlias* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
     {
         FCogDebugDraw::Point(*LogCategoryPtr, WorldContextObject, Location, Size, Color.ToFColor(true), Persistent, DepthPriority);
     }
@@ -30,7 +30,7 @@ void UCogDebugDrawBlueprint::DebugDrawPoint(const UObject* WorldContextObject, c
 void UCogDebugDrawBlueprint::DebugDrawSegment(const UObject* WorldContextObject, const FCogLogCategory LogCategory, const FVector SegmentStart, const FVector SegmentEnd, const FLinearColor Color, const bool Persistent, const uint8 DepthPriority)
 {
 #if ENABLE_COG
-    if (const FLogCategoryBase* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
+    if (const FCogLogCategoryAlias* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
     {
         FCogDebugDraw::Segment(*LogCategoryPtr, WorldContextObject, SegmentStart, SegmentEnd, Color.ToFColor(true), Persistent, DepthPriority);
     }
@@ -41,7 +41,7 @@ void UCogDebugDrawBlueprint::DebugDrawSegment(const UObject* WorldContextObject,
 void UCogDebugDrawBlueprint::DebugDrawArrow(const UObject* WorldContextObject, const FCogLogCategory LogCategory, const FVector SegmentStart, const FVector SegmentEnd, const FLinearColor Color, const bool Persistent, const uint8 DepthPriority)
 {
 #if ENABLE_COG
-    if (const FLogCategoryBase* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
+    if (const FCogLogCategoryAlias* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
     {
         FCogDebugDraw::Arrow(*LogCategoryPtr, WorldContextObject, SegmentStart, SegmentEnd, Color.ToFColor(true), Persistent, DepthPriority);
     }
@@ -52,7 +52,7 @@ void UCogDebugDrawBlueprint::DebugDrawArrow(const UObject* WorldContextObject, c
 void UCogDebugDrawBlueprint::DebugDrawAxis(const UObject* WorldContextObject, const FCogLogCategory LogCategory, const FVector Location, const FRotator Rotation, const float Scale, const bool Persistent, const uint8 DepthPriority)
 {
 #if ENABLE_COG
-    if (const FLogCategoryBase* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
+    if (const FCogLogCategoryAlias* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
     {
         FCogDebugDraw::Axis(*LogCategoryPtr, WorldContextObject, Location, Rotation, Scale, Persistent, DepthPriority);
     }
@@ -63,7 +63,7 @@ void UCogDebugDrawBlueprint::DebugDrawAxis(const UObject* WorldContextObject, co
 void UCogDebugDrawBlueprint::DebugDrawSphere(const UObject* WorldContextObject, const FCogLogCategory LogCategory, const FVector Location, const float Radius, const FLinearColor Color, const bool Persistent, const uint8 DepthPriority)
 {
 #if ENABLE_COG
-    if (const FLogCategoryBase* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
+    if (const FCogLogCategoryAlias* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
     {
         FCogDebugDraw::Sphere(*LogCategoryPtr, WorldContextObject, Location, Radius, Color.ToFColor(true), Persistent, DepthPriority);
     }
@@ -74,7 +74,7 @@ void UCogDebugDrawBlueprint::DebugDrawSphere(const UObject* WorldContextObject, 
 void UCogDebugDrawBlueprint::DebugDrawBox(const UObject* WorldContextObject, const FCogLogCategory LogCategory, const FVector Center, const FVector Extent, const FQuat Rotation, const FLinearColor Color, const bool Persistent, const uint8 DepthPriority)
 {
 #if ENABLE_COG
-    if (const FLogCategoryBase* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
+    if (const FCogLogCategoryAlias* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
     {
         FCogDebugDraw::Box(*LogCategoryPtr, WorldContextObject, Center, Extent, Rotation, Color.ToFColor(true), Persistent, DepthPriority);
     }
@@ -85,7 +85,7 @@ void UCogDebugDrawBlueprint::DebugDrawBox(const UObject* WorldContextObject, con
 void UCogDebugDrawBlueprint::DebugDrawSolidBox(const UObject* WorldContextObject, const FCogLogCategory LogCategory, const FVector Center, const FVector Extent, const FQuat Rotation, const FLinearColor Color, const bool Persistent, const uint8 DepthPriority)
 {
 #if ENABLE_COG
-    if (const FLogCategoryBase* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
+    if (const FCogLogCategoryAlias* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
     {
         FCogDebugDraw::SolidBox(*LogCategoryPtr, WorldContextObject, Center, Extent, Rotation, Color.ToFColor(true), Persistent, DepthPriority);
     }
@@ -96,7 +96,7 @@ void UCogDebugDrawBlueprint::DebugDrawSolidBox(const UObject* WorldContextObject
 void UCogDebugDrawBlueprint::DebugDrawCapsule(const UObject* WorldContextObject, const FCogLogCategory LogCategory, const FVector Center, const float HalfHeight, const float Radius, const FQuat Rotation, const FLinearColor Color, const bool Persistent, const uint8 DepthPriority)
 {
 #if ENABLE_COG
-    if (const FLogCategoryBase* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
+    if (const FCogLogCategoryAlias* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
     {
         FCogDebugDraw::Capsule(*LogCategoryPtr, WorldContextObject, Center, HalfHeight, Radius, Rotation, Color.ToFColor(true), Persistent, DepthPriority);
     }
@@ -107,7 +107,7 @@ void UCogDebugDrawBlueprint::DebugDrawCapsule(const UObject* WorldContextObject,
 void UCogDebugDrawBlueprint::DebugDrawCircle(const UObject* WorldContextObject, const FCogLogCategory LogCategory, const FMatrix& Matrix, const float Radius, const FLinearColor Color, const bool Persistent, const uint8 DepthPriority)
 {
 #if ENABLE_COG
-    if (const FLogCategoryBase* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
+    if (const FCogLogCategoryAlias* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
     {
         FCogDebugDraw::Circle(*LogCategoryPtr, WorldContextObject, Matrix, Radius, Color.ToFColor(true), Persistent, DepthPriority);
     }
@@ -118,7 +118,7 @@ void UCogDebugDrawBlueprint::DebugDrawCircle(const UObject* WorldContextObject, 
 void UCogDebugDrawBlueprint::DebugDrawCircleArc(const UObject* WorldContextObject, const FCogLogCategory LogCategory, const FMatrix& Matrix, const float InnerRadius, const float OuterRadius, const float Angle, const FLinearColor Color, const bool Persistent, uint8 DepthPriority)
 {
 #if ENABLE_COG
-    if (const FLogCategoryBase* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
+    if (const FCogLogCategoryAlias* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
     {
         FCogDebugDraw::CircleArc(*LogCategoryPtr, WorldContextObject, Matrix, InnerRadius, OuterRadius, Angle, Color.ToFColor(true), Persistent, DepthPriority);
     }
@@ -129,7 +129,7 @@ void UCogDebugDrawBlueprint::DebugDrawCircleArc(const UObject* WorldContextObjec
 void UCogDebugDrawBlueprint::DebugDrawPoints(const UObject* WorldContextObject, const FCogLogCategory LogCategory, const TArray<FVector>& Points, const float Radius, const FLinearColor StartColor, const FLinearColor EndColor, const bool Persistent, const uint8 DepthPriority)
 {
 #if ENABLE_COG
-    if (const FLogCategoryBase* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
+    if (const FCogLogCategoryAlias* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
     {
         FCogDebugDraw::Points(*LogCategoryPtr, WorldContextObject, Points, Radius, StartColor.ToFColor(true), EndColor.ToFColor(true), Persistent, DepthPriority);
     }
@@ -140,7 +140,7 @@ void UCogDebugDrawBlueprint::DebugDrawPoints(const UObject* WorldContextObject, 
 void UCogDebugDrawBlueprint::DebugDrawPath(const UObject* WorldContextObject, const FCogLogCategory LogCategory, const TArray<FVector>& Points, const float PointSize, const FLinearColor StartColor, const FLinearColor EndColor, const bool Persistent, const uint8 DepthPriority)
 {
 #if ENABLE_COG
-    if (const FLogCategoryBase* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
+    if (const FCogLogCategoryAlias* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
     {
         FCogDebugDraw::Path(*LogCategoryPtr, WorldContextObject, Points, PointSize, StartColor.ToFColor(true), EndColor.ToFColor(true), Persistent, DepthPriority);
     }
@@ -151,7 +151,7 @@ void UCogDebugDrawBlueprint::DebugDrawPath(const UObject* WorldContextObject, co
 void UCogDebugDrawBlueprint::DebugDrawString2D(const UObject* WorldContextObject, const FCogLogCategory LogCategory, const FString& Text, const FVector2D Location, const FLinearColor Color, const bool Persistent)
 {
 #if ENABLE_COG
-    if (const FLogCategoryBase* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
+    if (const FCogLogCategoryAlias* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
     {
         FCogDebugDraw::String2D(*LogCategoryPtr, WorldContextObject, Text, Location, Color.ToFColor(true), Persistent);
     }
@@ -162,7 +162,7 @@ void UCogDebugDrawBlueprint::DebugDrawString2D(const UObject* WorldContextObject
 void UCogDebugDrawBlueprint::DebugDrawSegment2D(const UObject* WorldContextObject, const FCogLogCategory LogCategory, const FVector2D SegmentStart, const FVector2D SegmentEnd, const FLinearColor Color, const bool Persistent)
 {
 #if ENABLE_COG
-    if (const FLogCategoryBase* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
+    if (const FCogLogCategoryAlias* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
     {
         FCogDebugDraw::Segment2D(*LogCategoryPtr, WorldContextObject, SegmentStart, SegmentEnd, Color.ToFColor(true), Persistent);
     }
@@ -173,7 +173,7 @@ void UCogDebugDrawBlueprint::DebugDrawSegment2D(const UObject* WorldContextObjec
 void UCogDebugDrawBlueprint::DebugDrawCircle2D(const UObject* WorldContextObject, const FCogLogCategory LogCategory, const FVector2D Location, const float Radius, const FLinearColor Color, const bool Persistent)
 {
 #if ENABLE_COG
-    if (const FLogCategoryBase* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
+    if (const FCogLogCategoryAlias* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
     {
         FCogDebugDraw::Circle2D(*LogCategoryPtr, WorldContextObject, Location, Radius, Color.ToFColor(true), Persistent);
     }
@@ -184,7 +184,7 @@ void UCogDebugDrawBlueprint::DebugDrawCircle2D(const UObject* WorldContextObject
 void UCogDebugDrawBlueprint::DebugDrawRect2D(const UObject* WorldContextObject, const FCogLogCategory LogCategory, const FVector2D Min, const FVector2D Max, const FLinearColor Color, const bool Persistent)
 {
 #if ENABLE_COG
-    if (const FLogCategoryBase* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
+    if (const FCogLogCategoryAlias* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
     {
         FCogDebugDraw::Rect2D(*LogCategoryPtr, WorldContextObject, Min, Max, Color.ToFColor(true), Persistent);
     }

--- a/Plugins/Cog/Source/CogDebug/Private/CogDebugLog.cpp
+++ b/Plugins/Cog/Source/CogDebug/Private/CogDebugLog.cpp
@@ -23,10 +23,12 @@ FString FCogDebugLogCategoryInfo::GetDisplayName() const
         return DisplayName;
     }
 
+#if !NO_LOGGING
     if (LogCategory != nullptr)
     {
         return LogCategory->GetCategoryName().ToString();
     }
+#endif //!NO_LOGGING
 
     return FString("Invalid");
 }
@@ -34,8 +36,9 @@ FString FCogDebugLogCategoryInfo::GetDisplayName() const
 //--------------------------------------------------------------------------------------------------------------------------
 // FCogDebugLogCategoryManager
 //--------------------------------------------------------------------------------------------------------------------------
-void FCogDebugLog::AddLogCategory(FLogCategoryBase& LogCategory, const FString& DisplayName, const FString& Description, const bool bVisible)
+void FCogDebugLog::AddLogCategory(FCogLogCategoryAlias& LogCategory, const FString& DisplayName, const FString& Description, const bool bVisible)
 {
+#if !NO_LOGGING
     LogCategories.Add(LogCategory.GetCategoryName(), 
         FCogDebugLogCategoryInfo
         {
@@ -45,6 +48,7 @@ void FCogDebugLog::AddLogCategory(FLogCategoryBase& LogCategory, const FString& 
             Description,
             bVisible,
             });
+#endif //!NO_LOGGING
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
@@ -54,26 +58,34 @@ bool FCogDebugLog::IsVerbosityActive(const ELogVerbosity::Type Verbosity)
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-bool FCogDebugLog::IsLogCategoryActive(const FLogCategoryBase& LogCategory)
+bool FCogDebugLog::IsLogCategoryActive(const FCogLogCategoryAlias& LogCategory)
 {
+#if !NO_LOGGING
     return IsVerbosityActive(LogCategory.GetVerbosity());
+#else //!NO_LOGGING
+    return false;
+#endif //!NO_LOGGING
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
 bool FCogDebugLog::IsLogCategoryActive(const FName CategoryName)
 {
-    if (const FLogCategoryBase* LogCategory = FindLogCategory(CategoryName))
+#if !NO_LOGGING
+    if (const FCogLogCategoryAlias* LogCategory = FindLogCategory(CategoryName))
     {
         return IsVerbosityActive(LogCategory->GetVerbosity());
     }
+#endif //!NO_LOGGING
 
     return false;
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-void FCogDebugLog::SetLogCategoryActive(FLogCategoryBase& LogCategory, const bool Value)
+void FCogDebugLog::SetLogCategoryActive(FCogLogCategoryAlias& LogCategory, const bool Value)
 {
+#if !NO_LOGGING
     LogCategory.SetVerbosity(Value ? ELogVerbosity::Verbose : ELogVerbosity::Warning);
+#endif //!NO_LOGGING
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
@@ -124,7 +136,7 @@ FCogDebugLogCategoryInfo* FCogDebugLog::FindLogCategoryInfo(const FName Category
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-FLogCategoryBase* FCogDebugLog::FindLogCategory(const FName CategoryName)
+FCogLogCategoryAlias* FCogDebugLog::FindLogCategory(const FName CategoryName)
 {
     if (const FCogDebugLogCategoryInfo* LogCategoryInfo = FindLogCategoryInfo(CategoryName))
     {
@@ -148,14 +160,9 @@ void FCogDebugLog::DeactivateAllLogCategories(UWorld& World)
 
 
 //--------------------------------------------------------------------------------------------------------------------------
-FLogCategoryBase* FCogDebugLog::GetLogCategoryBase(const FCogLogCategory& LogCategory)
+FCogLogCategoryAlias* FCogDebugLog::GetLogCategoryBase(const FCogLogCategory& LogCategory)
 {
-#if NO_LOGGING
-
-    return nullptr;
-
-#else
-
+#if !NO_LOGGING
     if (LogCategory.Name.IsNone() || LogCategory.Name.IsValid() == false)
     {
         return nullptr;
@@ -170,7 +177,8 @@ FLogCategoryBase* FCogDebugLog::GetLogCategoryBase(const FCogLogCategory& LogCat
     }
 
     return LogCategory.LogCategory;
-
-#endif //NO_LOGGING
+#else
+    return nullptr;
+#endif //!NO_LOGGING
 }
 

--- a/Plugins/Cog/Source/CogDebug/Private/CogDebugLogBlueprint.cpp
+++ b/Plugins/Cog/Source/CogDebug/Private/CogDebugLogBlueprint.cpp
@@ -9,7 +9,7 @@ void UCogDebugLogBlueprint::Log(const UObject* WorldContextObject, const FCogLog
 {
 #if ENABLE_COG
 
-    const FLogCategoryBase* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory);
+    const FCogLogCategoryAlias* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory);
 
     if (LogCategoryPtr == nullptr)
     {
@@ -35,7 +35,7 @@ bool UCogDebugLogBlueprint::IsLogActive(const UObject* WorldContextObject, const
 {
 #if ENABLE_COG
 
-    if (const FLogCategoryBase* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
+    if (const FCogLogCategoryAlias* LogCategoryPtr = FCogDebugLog::GetLogCategoryBase(LogCategory))
     {
         if (FCogDebugLog::IsLogCategoryActive(*LogCategoryPtr) == false)
         {

--- a/Plugins/Cog/Source/CogDebug/Private/CogDebugReplicator.cpp
+++ b/Plugins/Cog/Source/CogDebug/Private/CogDebugReplicator.cpp
@@ -120,7 +120,7 @@ void ACogDebugReplicator::TickActor(float DeltaTime, enum ELevelTick TickType, F
 //--------------------------------------------------------------------------------------------------------------------------
 void ACogDebugReplicator::Server_SetCategoryVerbosity_Implementation(FName LogCategoryName, ECogLogVerbosity Verbosity)
 {
-#if !UE_BUILD_SHIPPING
+#if !UE_BUILD_SHIPPING && !NO_LOGGING
 
 	const ENetMode NetMode = GetWorld()->GetNetMode();
     if (NetMode == NM_DedicatedServer || NetMode == NM_ListenServer)
@@ -135,7 +135,7 @@ void ACogDebugReplicator::Server_SetCategoryVerbosity_Implementation(FName LogCa
         }
     }
 
-#endif // !UE_BUILD_SHIPPING
+#endif // !UE_BUILD_SHIPPING && !NO_LOGGING
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
@@ -173,7 +173,7 @@ void ACogDebugReplicator::Client_SendCategoriesVerbosity_Implementation(const TA
 //--------------------------------------------------------------------------------------------------------------------------
 void ACogDebugReplicator::Server_RequestAllCategoriesVerbosity_Implementation()
 {
-#if !UE_BUILD_SHIPPING
+#if !UE_BUILD_SHIPPING && !NO_LOGGING
 
 	const ENetMode NetMode = GetWorld()->GetNetMode();
     if (NetMode == NM_DedicatedServer || NetMode == NM_ListenServer)
@@ -195,7 +195,7 @@ void ACogDebugReplicator::Server_RequestAllCategoriesVerbosity_Implementation()
         Client_SendCategoriesVerbosity(CategoriesData);
     }
 
-#endif // !UE_BUILD_SHIPPING
+#endif // !UE_BUILD_SHIPPING && !NO_LOGGING
 }
 
 //--------------------------------------------------------------------------------------------------------------------------

--- a/Plugins/Cog/Source/CogDebug/Public/CogDebugDraw.h
+++ b/Plugins/Cog/Source/CogDebug/Public/CogDebugDraw.h
@@ -13,53 +13,53 @@ struct FOverlapResult;
 
 struct COGDEBUG_API FCogDebugDraw
 {
-    static void String2D(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FString& Text, const FVector2D& Location, const FColor& Color, bool Persistent);
+    static void String2D(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FString& Text, const FVector2D& Location, const FColor& Color, bool Persistent);
 
-    static void Segment2D(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FVector2D& SegmentStart, const FVector2D& SegmentEnd, const FColor& Color, bool Persistent);
+    static void Segment2D(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FVector2D& SegmentStart, const FVector2D& SegmentEnd, const FColor& Color, bool Persistent);
     
-    static void Circle2D(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FVector2D& Location, float Radius, const FColor& Color, const bool Persistent);
+    static void Circle2D(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FVector2D& Location, float Radius, const FColor& Color, const bool Persistent);
     
-    static void Rect2D(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FVector2D& Min, const FVector2D& Max, const FColor& Color, const bool Persistent);
+    static void Rect2D(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FVector2D& Min, const FVector2D& Max, const FColor& Color, const bool Persistent);
 
-    static void String(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FString& Text, const FVector& Location, const FColor& Color, const bool Persistent);
+    static void String(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FString& Text, const FVector& Location, const FColor& Color, const bool Persistent);
     
-    static void Point(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FVector& Location, float Size, const FColor& Color, const bool Persistent, const uint8 DepthPriority = 0U);
+    static void Point(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FVector& Location, float Size, const FColor& Color, const bool Persistent, const uint8 DepthPriority = 0U);
     
-    static void Segment(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FVector& SegmentStart, const FVector& SegmentEnd, const FColor& Color, const bool Persistent, const uint8 DepthPriority = 0U);
+    static void Segment(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FVector& SegmentStart, const FVector& SegmentEnd, const FColor& Color, const bool Persistent, const uint8 DepthPriority = 0U);
     
-    static void Bone(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FVector& BoneLocation, const FVector& ParentLocation, const FColor& Color, const bool Persistent, const uint8 DepthPriority = 0U);
+    static void Bone(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FVector& BoneLocation, const FVector& ParentLocation, const FColor& Color, const bool Persistent, const uint8 DepthPriority = 0U);
     
-    static void Arrow(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FVector& SegmentStart, const FVector& SegmentEnd, const FColor& Color, const bool Persistent, const uint8 DepthPriority = 0U);
+    static void Arrow(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FVector& SegmentStart, const FVector& SegmentEnd, const FColor& Color, const bool Persistent, const uint8 DepthPriority = 0U);
     
-    static void Axis(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FVector& AxisLoc, const FRotator& AxisRot, float Scale, const bool Persistent, const uint8 DepthPriority = 0U);
+    static void Axis(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FVector& AxisLoc, const FRotator& AxisRot, float Scale, const bool Persistent, const uint8 DepthPriority = 0U);
     
-    static void Circle(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FMatrix& Matrix, float Radius, const FColor& Color, const bool Persistent, const uint8 DepthPriority = 0U);
+    static void Circle(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FMatrix& Matrix, float Radius, const FColor& Color, const bool Persistent, const uint8 DepthPriority = 0U);
     
-    static void CircleArc(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FMatrix& Matrix, float InnerRadius, float OuterRadius, float Angle, const FColor& Color, bool Persistent, const uint8 DepthPriority = 0U);
+    static void CircleArc(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FMatrix& Matrix, float InnerRadius, float OuterRadius, float Angle, const FColor& Color, bool Persistent, const uint8 DepthPriority = 0U);
     
-    static void FlatCapsule(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FVector2D& Start, const FVector2D& End, const float Radius, const float Z, const FColor& Color, const bool Persistent, const uint8 DepthPriority = 0U);
+    static void FlatCapsule(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FVector2D& Start, const FVector2D& End, const float Radius, const float Z, const FColor& Color, const bool Persistent, const uint8 DepthPriority = 0U);
     
-    static void Sphere(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FVector& Location, float Radius, const FColor& Color, bool Persistent, const uint8 DepthPriority = 0U);
+    static void Sphere(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FVector& Location, float Radius, const FColor& Color, bool Persistent, const uint8 DepthPriority = 0U);
     
-    static void Box(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FVector& Center, const FVector& Extent, const FQuat& Rotation, const FColor& Color, const bool Persistent, const uint8 DepthPriority = 0U);
+    static void Box(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FVector& Center, const FVector& Extent, const FQuat& Rotation, const FColor& Color, const bool Persistent, const uint8 DepthPriority = 0U);
     
-    static void SolidBox(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FVector& Center, const FVector& Extent, const FQuat& Rotation, const FColor& Color, const bool Persistent, const uint8 DepthPriority = 0U);
+    static void SolidBox(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FVector& Center, const FVector& Extent, const FQuat& Rotation, const FColor& Color, const bool Persistent, const uint8 DepthPriority = 0U);
     
-    static void Capsule(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FVector& Center, const float HalfHeight, const float Radius, const FQuat& Rotation, const FColor& Color, const bool Persistent, const uint8 DepthPriority = 0U);
+    static void Capsule(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FVector& Center, const float HalfHeight, const float Radius, const FQuat& Rotation, const FColor& Color, const bool Persistent, const uint8 DepthPriority = 0U);
     
-    static void Points(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const TArray<FVector>& Points, float Radius, const FColor& StartColor, const FColor& EndColor, const bool Persistent, const uint8 DepthPriority = 0U);
+    static void Points(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const TArray<FVector>& Points, float Radius, const FColor& StartColor, const FColor& EndColor, const bool Persistent, const uint8 DepthPriority = 0U);
     
-    static void Path(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const TArray<FVector>& Points, float PointSize, const FColor& StartColor, const FColor& EndColor, const bool Persistent, const uint8 DepthPriority = 0U);
+    static void Path(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const TArray<FVector>& Points, float PointSize, const FColor& StartColor, const FColor& EndColor, const bool Persistent, const uint8 DepthPriority = 0U);
     
-    static void Frustum(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FMatrix& Matrix, const float Angle, const float AspectRatio, const float NearPlane, const float FarPlane, const FColor& Color, const bool Persistent, const uint8 DepthPriority = 0U);
+    static void Frustum(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FMatrix& Matrix, const float Angle, const float AspectRatio, const float NearPlane, const float FarPlane, const FColor& Color, const bool Persistent, const uint8 DepthPriority = 0U);
     
-    static void Skeleton(const FLogCategoryBase& LogCategory, const USkeletalMeshComponent* Skeleton, const FColor& Color, bool DrawSecondaryBones = false, const uint8 DepthPriority = 1);
+    static void Skeleton(const FCogLogCategoryAlias& LogCategory, const USkeletalMeshComponent* Skeleton, const FColor& Color, bool DrawSecondaryBones = false, const uint8 DepthPriority = 1);
 
-    static void LineTrace(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FVector& Start, const FVector& End, const bool HasHits, TArray<FHitResult>& HitResults, const FCogDebugDrawLineTraceParams& Settings);
+    static void LineTrace(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FVector& Start, const FVector& End, const bool HasHits, TArray<FHitResult>& HitResults, const FCogDebugDrawLineTraceParams& Settings);
 
-    static void Sweep(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FCollisionShape& Shape, const FVector& Start, const FVector& End, const FQuat& Rotation, const bool HasHits, TArray<FHitResult>& HitResults, const FCogDebugDrawSweepParams& Settings);
+    static void Sweep(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FCollisionShape& Shape, const FVector& Start, const FVector& End, const FQuat& Rotation, const bool HasHits, TArray<FHitResult>& HitResults, const FCogDebugDrawSweepParams& Settings);
 
-    static void Overlap(const FLogCategoryBase& LogCategory, const UObject* WorldContextObject, const FCollisionShape& Shape, const FVector& Location, const FQuat& Rotation, const bool HasHits, TArray<FOverlapResult>& OverlapResults, const FCogDebugDrawOverlapParams& Settings);
+    static void Overlap(const FCogLogCategoryAlias& LogCategory, const UObject* WorldContextObject, const FCollisionShape& Shape, const FVector& Location, const FQuat& Rotation, const bool HasHits, TArray<FOverlapResult>& OverlapResults, const FCogDebugDrawOverlapParams& Settings);
 
     static void ReplicateShape(const UObject* WorldContextObject, const FCogDebugShape& Shape);
 

--- a/Plugins/Cog/Source/CogDebug/Public/CogDebugLog.h
+++ b/Plugins/Cog/Source/CogDebug/Public/CogDebugLog.h
@@ -1,6 +1,7 @@
 #pragma  once
 
 #include "CoreMinimal.h"
+#include "CogCommon.h"
 #include "Logging/LogVerbosity.h"
 
 struct FCogLogCategory;
@@ -12,7 +13,7 @@ DECLARE_LOG_CATEGORY_EXTERN(LogCogServerDebug, Verbose, All);
 //--------------------------------------------------------------------------------------------------------------------------
 struct COGDEBUG_API FCogDebugLogCategoryInfo
 {
-    FLogCategoryBase* LogCategory = nullptr;
+    FCogLogCategoryAlias* LogCategory = nullptr;
     
     ELogVerbosity::Type ServerVerbosity = ELogVerbosity::NoLogging;
     
@@ -28,19 +29,19 @@ struct COGDEBUG_API FCogDebugLogCategoryInfo
 //--------------------------------------------------------------------------------------------------------------------------
 struct COGDEBUG_API FCogDebugLog
 {
-    static void AddLogCategory(FLogCategoryBase& LogCategory, const FString& DisplayName = "", const FString& Description = "", bool bVisible = true);
+    static void AddLogCategory(FCogLogCategoryAlias& LogCategory, const FString& DisplayName = "", const FString& Description = "", bool bVisible = true);
 
     static bool IsVerbosityActive(ELogVerbosity::Type Verbosity);
 
-    static bool IsLogCategoryActive(const FLogCategoryBase& LogCategory);
+    static bool IsLogCategoryActive(const FCogLogCategoryAlias& LogCategory);
 
     static bool IsLogCategoryActive(FName CategoryName);
 
-    static void SetLogCategoryActive(FLogCategoryBase& LogCategory, bool Value);
+    static void SetLogCategoryActive(FCogLogCategoryAlias& LogCategory, bool Value);
 
-    static FLogCategoryBase* FindLogCategory(FName CategoryName);
+    static FCogLogCategoryAlias* FindLogCategory(FName CategoryName);
 
-    static FLogCategoryBase* GetLogCategoryBase(const FCogLogCategory& LogCategory);
+    static FCogLogCategoryAlias* GetLogCategoryBase(const FCogLogCategory& LogCategory);
 
     static FCogDebugLogCategoryInfo* FindLogCategoryInfo(FName CategoryName);
 

--- a/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_LogCategories.cpp
+++ b/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_LogCategories.cpp
@@ -109,6 +109,9 @@ void FCogEngineWindow_LogCategories::RenderContent()
         return;
     }
 
+#if NO_LOGGING
+    ImGui::Text("Logging is disabled.");
+#else //NO_LOGGING
     const bool IsClient = World->GetNetMode() == NM_Client;
 
     int Index = 0;
@@ -121,7 +124,7 @@ void FCogEngineWindow_LogCategories::RenderContent()
             continue;
         }
 
-        FLogCategoryBase* Category = CategoryInfo.LogCategory;
+        FCogLogCategoryAlias* Category = CategoryInfo.LogCategory;
 
         ImGui::PushID(Index);
         const auto CategoryFriendlyName = StringCast<ANSICHAR>(*CategoryInfo.GetDisplayName());
@@ -282,4 +285,5 @@ void FCogEngineWindow_LogCategories::RenderContent()
         ImGui::PopID();
         Index++;
     }
+#endif //NO_LOGGING
 }

--- a/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Notifications.cpp
+++ b/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Notifications.cpp
@@ -46,6 +46,7 @@ void FCogEngineWindow_Notifications::AddNotification(const TCHAR* InMessage, ELo
 //--------------------------------------------------------------------------------------------------------------------------
 void FCogEngineWindow_Notifications::OnLogReceived(const TCHAR* InMessage, ELogVerbosity::Type InVerbosity, const class FName& InCategory)
 {
+#if ENABLE_COG && !NO_LOGGING
     if (Config == nullptr)
     { return; }
 
@@ -54,7 +55,6 @@ void FCogEngineWindow_Notifications::OnLogReceived(const TCHAR* InMessage, ELogV
     
     static FName CmdName("Cmd");
 
-#if ENABLE_COG
     if (InCategory == LogCogNotify.GetCategoryName()
         || (InCategory == CmdName && Config->NotifyConsoleCommands)
         || (InVerbosity == ELogVerbosity::Warning && Config->NotifyAllWarnings)
@@ -62,7 +62,7 @@ void FCogEngineWindow_Notifications::OnLogReceived(const TCHAR* InMessage, ELogV
     {
         AddNotification(InMessage, InVerbosity);
     }
-#endif
+#endif //ENABLE_COG && !NO_LOGGING
 }
 
 

--- a/Source/CogSample/CogSampleFunctionLibrary_Gameplay.cpp
+++ b/Source/CogSample/CogSampleFunctionLibrary_Gameplay.cpp
@@ -270,7 +270,7 @@ bool UCogSampleFunctionLibrary_Gameplay::HasLineOfSight(
     const FVector& End,
     const FCollisionObjectQueryParams& BlockersParams,
     const FCollisionQueryParams& QueryParams,
-    const COG_LOG_CATEGORY& LogCategory)
+    const FCogLogCategoryAlias& LogCategory)
 {
     IF_COG(FCogDebugDraw::Sphere(LogCategory, World, Start, 5.0f, FColor::Black, false, 0));
     IF_COG(FCogDebugDraw::Sphere(LogCategory, World, End, 10.0f, FColor::Black, false, 0));

--- a/Source/CogSample/CogSampleFunctionLibrary_Gameplay.h
+++ b/Source/CogSample/CogSampleFunctionLibrary_Gameplay.h
@@ -104,7 +104,7 @@ public:
 
     static float ScreenToViewport(const float value, const FVector2D& displaySize);
 
-    static bool HasLineOfSight(const UWorld* World, const FVector& Start, const FVector& End, const FCollisionObjectQueryParams& BlockersParams, const FCollisionQueryParams& QueryParams, const COG_LOG_CATEGORY& LogCategory);
+    static bool HasLineOfSight(const UWorld* World, const FVector& Start, const FVector& End, const FCollisionObjectQueryParams& BlockersParams, const FCollisionQueryParams& QueryParams, const FCogLogCategoryAlias& LogCategory);
 
     static bool IsActorAbilitySystemMatchingTags(const UAbilitySystemComponent* AbilitySystem, const FGameplayTagContainer& RequiredTags, const FGameplayTagContainer& IgnoredTags);
 

--- a/Source/CogSample/CogSampleProjectileComponent.cpp
+++ b/Source/CogSample/CogSampleProjectileComponent.cpp
@@ -142,13 +142,13 @@ void UCogSampleProjectileComponent::Activate(bool bReset)
         Velocity = ServerSpawnVelocity;
     }
 
-#if ENABLE_COG
+#if ENABLE_COG && !NO_LOGGING
     DrawDebugCurrentState(FColor::Green);
     if (FCogDebugLog::IsLogCategoryActive(LogCogProjectile))
     {
         LastDebugLocation = GetOwner()->GetActorLocation();
     }
-#endif //ENABLE_COG
+#endif //ENABLE_COG && !NO_LOGGING
 
     //--------------------------------------------------------------------------
     // Catchup after settings LastDebugLocation because Tick will be triggered 
@@ -180,7 +180,7 @@ void UCogSampleProjectileComponent::TickComponent(float DeltaTime, enum ELevelTi
 
     //TravelingTime += DeltaTime;
 
-#if ENABLE_COG
+#if ENABLE_COG && !NO_LOGGING
 
     if (FCogDebugLog::IsLogCategoryActive(LogCogProjectile))
     {
@@ -215,7 +215,7 @@ void UCogSampleProjectileComponent::TickComponent(float DeltaTime, enum ELevelTi
 
     }
 
-#endif //ENABLE_COG
+#endif //ENABLE_COG && !NO_LOGGING
 }
 //--------------------------------------------------------------------------------------------------------------------------
 void UCogSampleProjectileComponent::Catchup(float CatchupDuration)

--- a/Source/CogSample/CogSampleTargetAcquisition.cpp
+++ b/Source/CogSample/CogSampleTargetAcquisition.cpp
@@ -551,7 +551,7 @@ bool UCogSampleTargetAcquisition::EvaluateCandidate(
     //--------------------------------------------------------------------------------------------------------------
     // Draw the score of each candidate
     //--------------------------------------------------------------------------------------------------------------
-#if ENABLE_COG
+#if ENABLE_COG && !NO_LOGGING
 
     if (FCogDebugLog::IsLogCategoryActive(LogCogTargetAcquisition))
     {
@@ -603,7 +603,7 @@ bool UCogSampleTargetAcquisition::EvaluateCandidate(
         FCogDebugDraw::String(LogCogTargetAcquisition, EvalParams.Controller, Text, CandidateTargetLocation, FColor::White, EvalParams.IsDebugPersistent);
     }
     
-#endif //ENABLE_COG
+#endif //ENABLE_COG && !NO_LOGGING
 
     return true;
 }


### PR DESCRIPTION
When trying to build in a configuration with `NO_LOGGING` that isn't Shipping (e.g. Test), there's a lot of errors related to log categories.
Following the examples in UE's `ProfilingDebugging/TraceScreenshot.h` file, I aliased the correct type depending on whether logging is enabled. I also corrected some macros that broke under the same circumstances.

Some parts of Cog could probably be completely disabled if logging is disabled, but I don't know enough about it yet to do that. This PR is only meant to fix compile errors, not optimally disable components.