### PR TITLE
Various fixes

### DIFF
--- a/Plugins/Cog/Source/Cog/Private/CogSubsystem.cpp
+++ b/Plugins/Cog/Source/Cog/Private/CogSubsystem.cpp
@@ -1081,7 +1081,7 @@ bool UCogSubsystem::BindShortcut(FCogShortcut& InShortcut) const
     
     InShortcut.InputChord = *InputChord;
 
-    FCogImguiInputHelper::GetPrioritizedShortcuts().Add(*InputChord);
+    FCogImguiInputHelper::GetPrioritizedShortcuts().AddUnique(*InputChord);
     return true;
 }
 

--- a/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Plots.cpp
+++ b/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Plots.cpp
@@ -438,7 +438,7 @@ void FCogEngineWindow_Plots::RenderPlots(FCogDebugTracker& InTracker)
                     //---------------------------------------------------------------------------
                     // Draw a vertical lines representing the current time and the mouse time
                     //---------------------------------------------------------------------------
-                    if (Config->ShowTimeBarAtGameTime || Config->ShowTimeBarAtGameTime)
+                    if (Config->ShowTimeBarAtGameTime || Config->ShowTimeBarAtCursor)
                     {
                         ImDrawList* PlotDrawList = ImPlot::GetPlotDrawList();
 

--- a/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Selection.cpp
+++ b/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Selection.cpp
@@ -248,16 +248,20 @@ bool FCogEngineWindow_Selection::TickSelectionMode()
         {
             if (UKismetSystemLibrary::LineTraceSingle(GetWorld(), WorldOrigin, WorldOrigin + WorldDirection * 10000, GetSelectionTraceChannel(), false, IgnoreList, EDrawDebugTrace::None, HitResult, true))
             {
-                if (SelectedActorClass == nullptr || HitResult.GetActor()->GetClass()->IsChildOf(SelectedActorClass))
+                AActor* HitActor = HitResult.GetActor();
+                if (HitActor != nullptr)
                 {
-                    HoveredActor = HitResult.GetActor();
-                    break;
-                }
+                    if (SelectedActorClass == nullptr || HitActor->GetClass()->IsChildOf(SelectedActorClass))
+                    {
+                        HoveredActor = HitActor;
+                        break;
+                    }
 
-                //------------------------------------------------
-                // The second time we accept the selected actor
-                //------------------------------------------------
-                IgnoreList.Empty();
+                    //------------------------------------------------
+                    // The second time we accept the selected actor
+                    //------------------------------------------------
+                    IgnoreList.Empty();
+                }
             }
         }
     }

--- a/Plugins/Cog/Source/CogImgui/Private/CogImguiContext.cpp
+++ b/Plugins/Cog/Source/CogImgui/Private/CogImguiContext.cpp
@@ -898,10 +898,15 @@ void FCogImguiContext::BuildFont()
     FontAtlasTexture->AddressX = TA_Wrap;
     FontAtlasTexture->AddressY = TA_Wrap;
 
-    uint8* FontAtlasTextureData = static_cast<uint8*>(FontAtlasTexture->GetPlatformData()->Mips[0].BulkData.Lock(LOCK_READ_WRITE));
-    FMemory::Memcpy(FontAtlasTextureData, TextureDataRaw, TextureWidth * TextureHeight * BytesPerPixel);
-    FontAtlasTexture->GetPlatformData()->Mips[0].BulkData.Unlock();
     FontAtlasTexture->UpdateResource();
+
+    FUpdateTextureRegion2D* TextureRegion = new FUpdateTextureRegion2D(0, 0, 0, 0, TextureWidth, TextureHeight);
+    auto DataCleanup = [](uint8* Data, const FUpdateTextureRegion2D* UpdateRegion)
+    {
+        delete UpdateRegion;
+    };
+    FontAtlasTexture->UpdateTextureRegions(0, 1u, TextureRegion, BytesPerPixel * TextureWidth, BytesPerPixel, TextureDataRaw, DataCleanup);
+    FlushRenderingCommands();
 
     IO.Fonts->SetTexID(FontAtlasTexture);
     FontAtlasTexturePtr.Reset(FontAtlasTexture);

--- a/Plugins/Cog/Source/CogImgui/Private/CogImguiContext.cpp
+++ b/Plugins/Cog/Source/CogImgui/Private/CogImguiContext.cpp
@@ -774,6 +774,7 @@ void FCogImguiContext::SetEnableInput(const bool InValue)
         if (bIsThrottleDisabled)
         {
             FSlateThrottleManager::Get().DisableThrottle(false);
+            bIsThrottleDisabled = false;
         }
         
         if (ULocalPlayer* LocalPlayer = GetLocalPlayer())


### PR DESCRIPTION
* Performance degradation due to duplicate shortcut registration.
* Fix a copy paste error causing ShowTimeBarAtCursor not to work in Plots
* Fix a crash when using the actor picker with BSP Brushes
* Fix mismatched calls to FSlateThrottleManager::DisableThrottle
* Fix corrupted fonts on console