### PR TITLE
Make the cog available to placed into engine/plugins & Add chinese-support option

### DIFF
--- a/Plugins/Cog/Source/Cog/Private/CogSubsystem.cpp
+++ b/Plugins/Cog/Source/Cog/Private/CogSubsystem.cpp
@@ -268,7 +268,7 @@ void UCogSubsystem::Tick(float InDeltaTime)
     if (LayoutToLoad != -1)
     {
 	    const FString Filename = FCogImguiHelper::GetIniFilePath(FString::Printf(TEXT("ImGui_Layout_%d"), LayoutToLoad));
-        ImGui::LoadIniSettingsFromDisk(TCHAR_TO_ANSI(*Filename));
+        ImGui::LoadIniSettingsFromDisk(COG_TCHAR_TO_CHAR(*Filename));
         LayoutToLoad = -1;
     }
 
@@ -466,7 +466,7 @@ void UCogSubsystem::ResetLayout()
 
     for (const FCogWindow* Window : Windows)
     {
-        ImGui::SetWindowPos(TCHAR_TO_ANSI(*Window->GetName()), ImVec2(10, 10), ImGuiCond_Always);
+        ImGui::SetWindowPos(COG_TCHAR_TO_CHAR(*Window->GetName()), ImVec2(10, 10), ImGuiCond_Always);
     }
 
     ImGui::ClearIniSettings();
@@ -498,7 +498,7 @@ void UCogSubsystem::SaveLayout(const int32 LayoutIndex)
     FCogImGuiContextScope ImGuiContextScope(Context);
 
 	const FString Filename = *FCogImguiHelper::GetIniFilePath(FString::Printf(TEXT("imgui_layout_%d"), LayoutIndex));
-    ImGui::SaveIniSettingsToDisk(TCHAR_TO_ANSI(*Filename));
+    ImGui::SaveIniSettingsToDisk(COG_TCHAR_TO_CHAR(*Filename));
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
@@ -582,7 +582,7 @@ void UCogSubsystem::RenderMainMenu()
                 for (FCogWindow* SpaceWindow : SpaceWindows)
                 {
                     bool bSpaceVisible = SpaceWindow->GetIsVisible();
-                    if (ImGui::MenuItem(TCHAR_TO_ANSI(*SpaceWindow->GetName()), nullptr, &bSpaceVisible))
+                    if (ImGui::MenuItem(COG_TCHAR_TO_CHAR(*SpaceWindow->GetName()), nullptr, &bSpaceVisible))
                     {
                         SpaceWindow->SetIsVisible(bSpaceVisible);
                     }
@@ -712,11 +712,11 @@ void UCogSubsystem::RenderOptionMenu(FMenu& Menu)
 {
     if (Menu.Window != nullptr)
     {
-        RenderMenuItem(*Menu.Window, TCHAR_TO_ANSI(*Menu.Name));
+        RenderMenuItem(*Menu.Window, COG_TCHAR_TO_CHAR(*Menu.Name));
     }
     else
     {
-        if (ImGui::BeginMenu(TCHAR_TO_ANSI(*Menu.Name)))
+        if (ImGui::BeginMenu(COG_TCHAR_TO_CHAR(*Menu.Name)))
         {
             for (FMenu& SubMenu : Menu.SubMenus)
             {

--- a/Plugins/Cog/Source/Cog/Private/CogWidgets.cpp
+++ b/Plugins/Cog/Source/Cog/Private/CogWidgets.cpp
@@ -1,5 +1,6 @@
 #include "CogWidgets.h"
 
+#include "CogCommon.h"
 #include "CogDebug.h"
 #include "CogImguiHelper.h"
 #include "CogImguiInputHelper.h"
@@ -417,7 +418,7 @@ bool FCogWidgets::ComboboxEnum(const char* Label, const UEnum* Enum, int64 Curre
 
     FString CurrentEntryName = Enum->GetNameStringByValue(CurrentValue);
 
-    if (ImGui::BeginCombo(Label, TCHAR_TO_ANSI(*CurrentEntryName)))
+    if (ImGui::BeginCombo(Label, COG_TCHAR_TO_CHAR(*CurrentEntryName)))
     {
         for (int32 EnumIndex = 0; EnumIndex < Enum->NumEnums() - 1; ++EnumIndex)
         {
@@ -433,7 +434,7 @@ bool FCogWidgets::ComboboxEnum(const char* Label, const UEnum* Enum, int64 Curre
 
             bool IsSelected = EnumEntryName == CurrentEntryName;
 
-            if (ImGui::Selectable(TCHAR_TO_ANSI(*EnumEntryName), IsSelected))
+            if (ImGui::Selectable(COG_TCHAR_TO_CHAR(*EnumEntryName), IsSelected))
             {
                 HasChanged = true;
                 NewValue = EnumEntryValue;
@@ -570,7 +571,7 @@ bool FCogWidgets::InputChord(FInputChord& InInputChord)
 bool FCogWidgets::Key(FKey& InKey)
 {
     bool HasKeyChanged = false;
-    if (ImGui::BeginCombo("##Key", TCHAR_TO_ANSI(*InKey.ToString()), ImGuiComboFlags_HeightLarge))
+    if (ImGui::BeginCombo("##Key", COG_TCHAR_TO_CHAR(*InKey.ToString()), ImGuiComboFlags_HeightLarge))
     {
         {
             bool IsSelected = InKey == FKey();
@@ -598,7 +599,7 @@ bool FCogWidgets::Key(FKey& InKey)
             }
 
             bool IsSelected = InKey == Key;
-            if (ImGui::Selectable(TCHAR_TO_ANSI(*Key.ToString()), IsSelected))
+            if (ImGui::Selectable(COG_TCHAR_TO_CHAR(*Key.ToString()), IsSelected))
             {
                 InKey = Key;
                 HasKeyChanged = true;
@@ -835,7 +836,7 @@ bool FCogWidgets::ComboTraceChannel(const char* Label, ECollisionChannel& Channe
     const FName SelectedChannelName = CollisionProfile->ReturnChannelNameFromContainerIndex(Channel);
     
     bool Result = false;
-    if (ImGui::BeginCombo(Label, TCHAR_TO_ANSI(*SelectedChannelName.ToString()), ImGuiComboFlags_HeightLarge))
+    if (ImGui::BeginCombo(Label, COG_TCHAR_TO_CHAR(*SelectedChannelName.ToString()), ImGuiComboFlags_HeightLarge))
     {
         for (int32 ChannelIndex = 0; ChannelIndex < static_cast<int32>(ECC_OverlapAll_Deprecated); ++ChannelIndex)
         {
@@ -851,7 +852,7 @@ bool FCogWidgets::ComboTraceChannel(const char* Label, ECollisionChannel& Channe
             const FName ChannelName = CollisionProfile->ReturnChannelNameFromContainerIndex(ChannelIndex);
             if (ChannelName.IsValid())
             {
-                if (ImGui::Selectable(TCHAR_TO_ANSI(*ChannelName.ToString())))
+                if (ImGui::Selectable(COG_TCHAR_TO_CHAR(*ChannelName.ToString())))
                 {
                     Channel = static_cast<ECollisionChannel>(ChannelIndex);
                     Result = true;
@@ -876,7 +877,7 @@ bool FCogWidgets::CollisionProfileChannel(const UCollisionProfile& InCollisionPr
 
     bool IsCollisionActive = (InChannels & ECC_TO_BITFIELD(InChannelIndex)) > 0;
     const FName ChannelName = InCollisionProfile.ReturnChannelNameFromContainerIndex(InChannelIndex);
-    if (ImGui::Checkbox(TCHAR_TO_ANSI(*ChannelName.ToString()), &IsCollisionActive))
+    if (ImGui::Checkbox(COG_TCHAR_TO_CHAR(*ChannelName.ToString()), &IsCollisionActive))
     {
         Result = true;
 
@@ -973,12 +974,12 @@ bool FCogWidgets::ActorsListWithFilters(AActor*& NewSelection, const UWorld& Wor
     if (ActorClasses.Num() > 1)
     {
         ImGui::SetNextItemWidth(18 * GetFontWidth());
-        if (ImGui::BeginCombo("##SelectionType", TCHAR_TO_ANSI(*GetNameSafe(SelectedClass))))
+        if (ImGui::BeginCombo("##SelectionType", COG_TCHAR_TO_CHAR(*GetNameSafe(SelectedClass))))
         {
             for (int32 i = 0; i < ActorClasses.Num(); ++i)
             {
                 TSubclassOf<AActor> SubClass = ActorClasses[i];
-                if (ImGui::Selectable(TCHAR_TO_ANSI(*GetNameSafe(SubClass)), false))
+                if (ImGui::Selectable(COG_TCHAR_TO_CHAR(*GetNameSafe(SubClass)), false))
                 {
                     SelectedActorClassIndex = i;
                     SelectedClass = SubClass;
@@ -1054,7 +1055,7 @@ bool FCogWidgets::ActorsList(AActor*& NewSelection, const UWorld& World, const T
             ImGui::PushStyleColor(ImGuiCol_Text, Actor == LocalPlayerPawn ? IM_COL32(255, 255, 0, 255) : IM_COL32(255, 255, 255, 255));
 
             const bool bIsSelected = Actor == FCogDebug::GetSelection();
-            if (ImGui::Selectable(TCHAR_TO_ANSI(*FCogHelper::GetActorName(*Actor)), bIsSelected))
+            if (ImGui::Selectable(COG_TCHAR_TO_CHAR(*FCogHelper::GetActorName(*Actor)), bIsSelected))
             {
                 //FCogDebug::SetSelection(&World, Actor);
                 NewSelection = Actor;
@@ -1123,13 +1124,13 @@ bool FCogWidgets::MenuActorsCombo(const char* StrID, AActor*& NewSelection, cons
         }
 
         const FString CurrentSelectionName = FCogHelper::GetActorName(Selection);
-        if (ImGui::Button(TCHAR_TO_ANSI(*CurrentSelectionName), ImVec2(Width, 0.0f)))
+        if (ImGui::Button(COG_TCHAR_TO_CHAR(*CurrentSelectionName), ImVec2(Width, 0.0f)))
         {
             ImGui::OpenPopup("ActorListPopup");
         }
         if (ImGui::IsItemHovered())
         {
-            ImGui::SetTooltip("Current Selection: %s", TCHAR_TO_ANSI(*CurrentSelectionName));
+            ImGui::SetTooltip("Current Selection: %s", COG_TCHAR_TO_CHAR(*CurrentSelectionName));
         }
 
         ImGui::PopStyleColor(1);
@@ -1239,7 +1240,7 @@ void FCogWidgets::ActorFrame(const AActor& Actor)
         {
             DrawList->AddRect(FCogImguiHelper::ToImVec2(ScreenPosMin) + Viewport->Pos, FCogImguiHelper::ToImVec2(ScreenPosMax) + Viewport->Pos, Color, 0.0f, 0, 1.0f);
         }
-        AddTextWithShadow(DrawList, FCogImguiHelper::ToImVec2(ScreenPosMin + FVector2D(0, -14.0f)) + Viewport->Pos, Color, TCHAR_TO_ANSI(*FCogHelper::GetActorName(Actor)));
+        AddTextWithShadow(DrawList, FCogImguiHelper::ToImVec2(ScreenPosMin + FVector2D(0, -14.0f)) + Viewport->Pos, Color, COG_TCHAR_TO_CHAR(*FCogHelper::GetActorName(Actor)));
     }
 }
 
@@ -1257,7 +1258,7 @@ void FCogWidgets::SmallButton(const char* Text, const ImVec4& Color)
 bool FCogWidgets::InputText(const char* Text, FString& Value, ImGuiInputTextFlags InFlags, ImGuiInputTextCallback InCallback, void* InUserData)
 {
     static char ValueBuffer[256] = "";
-    ImStrncpy(ValueBuffer, TCHAR_TO_ANSI(*Value), IM_ARRAYSIZE(ValueBuffer));
+    ImStrncpy(ValueBuffer, COG_TCHAR_TO_CHAR(*Value), IM_ARRAYSIZE(ValueBuffer));
     
     bool result = ImGui::InputText(Text, ValueBuffer, IM_ARRAYSIZE(ValueBuffer), InFlags, InCallback, InUserData);
     if (result)
@@ -1272,7 +1273,7 @@ bool FCogWidgets::InputText(const char* Text, FString& Value, ImGuiInputTextFlag
 bool FCogWidgets::InputTextWithHint(const char* InText, const char* InHint, FString& InValue, ImGuiInputTextFlags InFlags, ImGuiInputTextCallback InCallback, void* InUserData)
 {
     static char ValueBuffer[256] = "";
-    ImStrncpy(ValueBuffer, TCHAR_TO_ANSI(*InValue), IM_ARRAYSIZE(ValueBuffer));
+    ImStrncpy(ValueBuffer, COG_TCHAR_TO_CHAR(*InValue), IM_ARRAYSIZE(ValueBuffer));
 
     bool result = ImGui::InputTextWithHint(InText, InHint, ValueBuffer, IM_ARRAYSIZE(ValueBuffer), InFlags, InCallback, InUserData);
     if (result)

--- a/Plugins/Cog/Source/Cog/Private/CogWindow.cpp
+++ b/Plugins/Cog/Source/Cog/Private/CogWindow.cpp
@@ -1,5 +1,6 @@
 #include "CogWindow.h"
 
+#include "CogCommon.h"
 #include "CogDebug.h"
 #include "CogWindow_Settings.h"
 #include "CogSubsystem.h"
@@ -41,7 +42,7 @@ void FCogWindow::SetFullName(const FString& InFullName)
 
     Title = Name;
 
-    ID = ImHashStr(TCHAR_TO_ANSI(*FullName));
+    ID = ImHashStr(COG_TCHAR_TO_CHAR(*FullName));
 }
 
 //--------------------------------------------------------------------------------------------------------------------------

--- a/Plugins/Cog/Source/Cog/Private/CogWindow_Settings.cpp
+++ b/Plugins/Cog/Source/Cog/Private/CogWindow_Settings.cpp
@@ -1,5 +1,6 @@
 #include "CogWindow_Settings.h"
 
+#include "CogCommon.h"
 #include "CogImguiHelper.h"
 #include "CogImguiInputHelper.h"
 #include "CogSubsystem.h"
@@ -215,7 +216,7 @@ void FCogWindow_Settings::RenderContent()
                 }
                 
                 ImGui::SameLine();
-                ImGui::Selectable(TCHAR_TO_ANSI(*Window->GetName()), false, ImGuiSelectableFlags_SpanAvailWidth);
+                ImGui::Selectable(COG_TCHAR_TO_CHAR(*Window->GetName()), false, ImGuiSelectableFlags_SpanAvailWidth);
                 {
                     Window->SetIsWidgetVisible(Visible);
                 }

--- a/Plugins/Cog/Source/CogCommon/Public/CogCommon.h
+++ b/Plugins/Cog/Source/CogCommon/Public/CogCommon.h
@@ -3,6 +3,7 @@
 #include "CoreMinimal.h"
 #include "Templates/IsArrayOrRefOfType.h"
 #include "CogCommonLogCategory.h"
+#include "CogLocalizationConfig.h"
 
 #ifndef ENABLE_COG
 #define ENABLE_COG !UE_BUILD_SHIPPING

--- a/Plugins/Cog/Source/CogCommon/Public/CogCommonLog.h
+++ b/Plugins/Cog/Source/CogCommon/Public/CogCommonLog.h
@@ -25,7 +25,7 @@ struct COGCOMMON_API FCogLogCategory
 
     FCogLogCategory() {}
 
-    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cog")
     FName Name;
 
     FString GetName() const { return Name.ToString(); }

--- a/Plugins/Cog/Source/CogCommon/Public/CogLocalizationConfig.h
+++ b/Plugins/Cog/Source/CogCommon/Public/CogLocalizationConfig.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#ifndef COG_SUPPORT_CHINESE
+#define COG_SUPPORT_CHINESE 0
+#endif
+
+#if COG_SUPPORT_CHINESE
+#define COG_TCHAR_TO_CHAR TCHAR_TO_UTF8
+#else
+#define COG_TCHAR_TO_CHAR TCHAR_TO_ANSI
+#endif

--- a/Plugins/Cog/Source/CogDebug/Private/CogDebugDrawImGui.cpp
+++ b/Plugins/Cog/Source/CogDebug/Private/CogDebugDrawImGui.cpp
@@ -1,5 +1,6 @@
 #include "CogDebugDrawImGui.h"
 
+#include "CogCommon.h"
 #include "imgui_internal.h"
 
 //--------------------------------------------------------------------------------------------------------------------------
@@ -194,5 +195,5 @@ void FCogDebugDrawImGui::Draw()
     DrawShapes(TrianglesFilled, [DrawList](const FTriangle& Triangle, const ImColor Color) { DrawList->AddTriangleFilled(Triangle.P1, Triangle.P2, Triangle.P3, Color); });
     DrawShapes(Circles, [DrawList](const FCircle& Circle, const ImColor Color) { DrawList->AddCircle(Circle.Center, Circle.Radius, Color, Circle.Segments, Circle.Thickness); });
     DrawShapes(CirclesFilled, [DrawList](const FCircle& Circle, const ImColor Color) { DrawList->AddCircleFilled(Circle.Center, Circle.Radius, Color, Circle.Segments); });
-    DrawShapes(Texts, [DrawList](const FText& Text, const ImColor Color) { DrawList->AddText(Text.Pos, Color, TCHAR_TO_ANSI(*Text.Text)); });
+    DrawShapes(Texts, [DrawList](const FText& Text, const ImColor Color) { DrawList->AddText(Text.Pos, Color, COG_TCHAR_TO_CHAR(*Text.Text)); });
 }

--- a/Plugins/Cog/Source/CogDebug/Public/CogDebugDrawBlueprint.h
+++ b/Plugins/Cog/Source/CogDebug/Public/CogDebugDrawBlueprint.h
@@ -12,55 +12,55 @@ class COGDEBUG_API UCogDebugDrawBlueprint : public UBlueprintFunctionLibrary
 
 public:
 
-    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"))
+    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"), Category = "Cog")
     static void DebugDrawString(const UObject* WorldContextObject, FCogLogCategory LogCategory, const FString& Text, const FVector Location, const FLinearColor Color, bool Persistent);
 
-    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"))
+    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"), Category = "Cog")
     static void DebugDrawPoint(const UObject* WorldContextObject, FCogLogCategory LogCategory, const FVector Location, float size, const FLinearColor Color, bool Persistent, uint8 DepthPriority);
 
-    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"))
+    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"), Category = "Cog")
     static void DebugDrawSegment(const UObject* WorldContextObject, FCogLogCategory LogCategory, const FVector SegmentStart, const FVector SegmentEnd, const FLinearColor Color, bool Persistent, uint8 DepthPriority);
 
-    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"))
+    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"), Category = "Cog")
     static void DebugDrawArrow(const UObject* WorldContextObject, FCogLogCategory LogCategory, const FVector SegmentStart, const FVector SegmentEnd, const FLinearColor Color, bool Persistent, uint8 DepthPriority);
 
-    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"))
+    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"), Category = "Cog")
     static void DebugDrawAxis(const UObject* WorldContextObject, FCogLogCategory LogCategory, const FVector Location, const FRotator Rotation, float Scale, bool Persistent, uint8 DepthPriority);
 
-    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"))
+    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"), Category = "Cog")
     static void DebugDrawSphere(const UObject* WorldContextObject, FCogLogCategory LogCategory, const FVector Location, float Radius, const FLinearColor Color, bool Persistent, uint8 DepthPriority);
 
-    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"))
+    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"), Category = "Cog")
     static void DebugDrawBox(const UObject* WorldContextObject, FCogLogCategory LogCategory, const FVector Center, const FVector Extent, const FQuat Rotation, const FLinearColor Color, bool Persistent, uint8 DepthPriority);
 
-    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"))
+    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"), Category = "Cog")
     static void DebugDrawSolidBox(const UObject* WorldContextObject, FCogLogCategory LogCategory, const FVector Center, const FVector Extent, const FQuat Rotation, const FLinearColor Color, bool Persistent, uint8 DepthPriority);
 
-    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"))
+    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"), Category = "Cog")
     static void DebugDrawCapsule(const UObject* WorldContextObject, FCogLogCategory LogCategory, const FVector Center, const float HalfHeight, const float Radius, const FQuat Rotation, const FLinearColor Color, bool Persistent, uint8 DepthPriority);
 
-    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"))
+    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"), Category = "Cog")
     static void DebugDrawCircle(const UObject* WorldContextObject, FCogLogCategory LogCategory, const FMatrix& Matrix, float Radius, const FLinearColor Color, bool Persistent, uint8 DepthPriority);
     
-    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"))
+    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"), Category = "Cog")
     static void DebugDrawCircleArc(const UObject* WorldContextObject, FCogLogCategory LogCategory, const FMatrix& Matrix, float InnerRadius, float OuterRadius, float Angle, const FLinearColor Color, bool Persistent, uint8 DepthPriority);
 
-    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"))
+    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"), Category = "Cog")
     static void DebugDrawPoints(const UObject* WorldContextObject, FCogLogCategory LogCategory, const TArray<FVector>& Points, float Radius, const FLinearColor StartColor, const FLinearColor EndColor, bool Persistent, uint8 DepthPriority);
 
-    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"))
+    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"), Category = "Cog")
     static void DebugDrawPath(const UObject* WorldContextObject, FCogLogCategory LogCategory, const TArray<FVector>& Points, float PointSize, const FLinearColor StartColor, const FLinearColor EndColor, bool Persistent, uint8 DepthPriority);
 
-    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"))
+    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"), Category = "Cog")
     static void DebugDrawString2D(const UObject* WorldContextObject, FCogLogCategory LogCategory, const FString& Text, const FVector2D Location, const FLinearColor Color, bool Persistent);
     
-    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"))
+    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"), Category = "Cog")
     static void DebugDrawSegment2D(const UObject* WorldContextObject, FCogLogCategory LogCategory, const FVector2D SegmentStart, const FVector2D SegmentEnd, const FLinearColor Color, bool Persistent);
 
-    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"))
+    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"), Category = "Cog")
     static void DebugDrawCircle2D(const UObject* WorldContextObject, FCogLogCategory LogCategory, const FVector2D Location, float Radius, const FLinearColor Color, bool Persistent);
 
-    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"))
+    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"), Category = "Cog")
     static void DebugDrawRect2D(const UObject* WorldContextObject, FCogLogCategory LogCategory, const FVector2D Min, const FVector2D Max, const FLinearColor Color, bool Persistent);
 
 };

--- a/Plugins/Cog/Source/CogDebug/Public/CogDebugLogBlueprint.h
+++ b/Plugins/Cog/Source/CogDebug/Public/CogDebugLogBlueprint.h
@@ -14,10 +14,10 @@ class COGDEBUG_API UCogDebugLogBlueprint : public UBlueprintFunctionLibrary
 
 public:
 
-    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"))
+    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"), Category = "Cog")
     static void Log(const UObject* WorldContextObject, FCogLogCategory LogCategory, ECogLogVerbosity Verbosity = ECogLogVerbosity::Verbose, const FString& Text = FString(""));
 
-    UFUNCTION(BlueprintPure, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"))
+    UFUNCTION(BlueprintPure, meta = (DevelopmentOnly, WorldContext = "WorldContextObject"), Category = "Cog")
     static bool IsLogActive(const UObject* WorldContextObject, const FCogLogCategory LogCategory);
 
 };

--- a/Plugins/Cog/Source/CogDebug/Public/CogDebugPlotBlueprint.h
+++ b/Plugins/Cog/Source/CogDebug/Public/CogDebugPlotBlueprint.h
@@ -11,6 +11,6 @@ class COGDEBUG_API UCogDebugPlotBlueprint : public UBlueprintFunctionLibrary
 
 public:
 
-    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly))
+    UFUNCTION(BlueprintCallable, meta = (DevelopmentOnly), Category = "Cog")
     static void Plot(const UObject* Owner, const FName Name, const float Value);
 };

--- a/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_CollisionTester.cpp
+++ b/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_CollisionTester.cpp
@@ -1,5 +1,6 @@
 #include "CogEngineWindow_CollisionTester.h"
 
+#include "CogCommon.h"
 #include "CogDebug.h"
 #include "CogImguiHelper.h"
 #include "CogWidgets.h"
@@ -149,12 +150,12 @@ void FCogEngineWindow_CollisionTester::RenderContent()
         const FName SelectedProfileName = SelectedProfile != nullptr ? SelectedProfile->Name : FName("Custom");
 
         FCogWidgets::SetNextItemToShortWidth();
-        if (ImGui::BeginCombo("Profile", TCHAR_TO_ANSI(*SelectedProfileName.ToString()), ImGuiComboFlags_HeightLargest))
+        if (ImGui::BeginCombo("Profile", COG_TCHAR_TO_CHAR(*SelectedProfileName.ToString()), ImGuiComboFlags_HeightLargest))
         {
             for (int i = 0; i < CollisionProfile->GetNumOfProfiles(); ++i)
             {
                 const FCollisionResponseTemplate* Profile = CollisionProfile->GetProfileByIndex(i);
-                if (ImGui::Selectable(TCHAR_TO_ANSI(*Profile->Name.ToString()), false))
+                if (ImGui::Selectable(COG_TCHAR_TO_CHAR(*Profile->Name.ToString()), false))
                 {
                     CollisionTester->ProfileIndex = i;
                     CollisionTester->ObjectTypesToQuery = 0;

--- a/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_CollisionViewer.cpp
+++ b/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_CollisionViewer.cpp
@@ -1,5 +1,6 @@
 #include "CogEngineWindow_CollisionViewer.h"
 
+#include "CogCommon.h"
 #include "CogDebugDrawHelper.h"
 #include "CogDebug.h"
 #include "CogImguiHelper.h"
@@ -104,12 +105,12 @@ void FCogEngineWindow_CollisionViewer::RenderContent()
     const FCollisionResponseTemplate* SelectedProfile = CollisionProfile->GetProfileByIndex(Config->ProfileIndex);
     FName SelectedProfileName = SelectedProfile != nullptr ? SelectedProfile->Name : FName("Custom");
 
-    if (ImGui::BeginCombo("Profile", TCHAR_TO_ANSI(*SelectedProfileName.ToString()), ImGuiComboFlags_HeightLargest))
+    if (ImGui::BeginCombo("Profile", COG_TCHAR_TO_CHAR(*SelectedProfileName.ToString()), ImGuiComboFlags_HeightLargest))
     {
         for (int i = 0; i < CollisionProfile->GetNumOfProfiles(); ++i)
         {
             const FCollisionResponseTemplate* Profile = CollisionProfile->GetProfileByIndex(i);
-            if (ImGui::Selectable(TCHAR_TO_ANSI(*Profile->Name.ToString()), false))
+            if (ImGui::Selectable(COG_TCHAR_TO_CHAR(*Profile->Name.ToString()), false))
             {
                 Config->ProfileIndex = i;
                 Config->ObjectTypesToQuery = 0;

--- a/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Inspector.cpp
+++ b/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Inspector.cpp
@@ -1,5 +1,6 @@
 #include "CogEngineWindow_Inspector.h"
 
+#include "CogCommon.h"
 #include "CogWidgets.h"
 #include "Containers/SortedMap.h"
 #include "Engine/Engine.h"
@@ -204,7 +205,7 @@ void FCogEngineWindow_Inspector::RenderMenu()
             for (FFavorite& Favorite : Favorites)
             {
                 const TWeakObjectPtr<UObject>& Object = Favorite.Object;
-                if (ImGui::MenuItem(TCHAR_TO_ANSI(*GetNameSafe(Object.Get()))))
+                if (ImGui::MenuItem(COG_TCHAR_TO_CHAR(*GetNameSafe(Object.Get()))))
                 {
                     SetInspectedObject(Object.Get());
                     ImGui::CloseCurrentPopup();
@@ -222,7 +223,7 @@ void FCogEngineWindow_Inspector::RenderMenu()
             {
                 ImGui::PushID(i);
                 const TWeakObjectPtr<const UObject>& Object = History[i];
-                if (ImGui::MenuItem(TCHAR_TO_ANSI(*GetNameSafe(Object.Get())), nullptr, i == HistoryIndex))
+                if (ImGui::MenuItem(COG_TCHAR_TO_CHAR(*GetNameSafe(Object.Get())), nullptr, i == HistoryIndex))
                 {
                     NewHistoryIndex = i;
                     ImGui::CloseCurrentPopup();
@@ -305,7 +306,7 @@ bool FCogEngineWindow_Inspector::RenderInspector()
     {
         const FProperty* Property = *It;
 
-        if (Filter.IsActive() == false || Filter.PassFilter(TCHAR_TO_ANSI(*Property->GetName())))
+        if (Filter.IsActive() == false || Filter.PassFilter(COG_TCHAR_TO_CHAR(*Property->GetName())))
         {
             Properties.Add(Property);
         }
@@ -482,11 +483,11 @@ bool FCogEngineWindow_Inspector::RenderProperty(const FProperty* Property, uint8
     bool ShowChildren = false;
     if (HasPropertyAnyChildren(Property, PointerToValue))
     {
-        ShowChildren = ImGui::TreeNodeEx(TCHAR_TO_ANSI(*PropertyName), ImGuiTreeNodeFlags_SpanFullWidth);
+        ShowChildren = ImGui::TreeNodeEx(COG_TCHAR_TO_CHAR(*PropertyName), ImGuiTreeNodeFlags_SpanFullWidth);
     }
     else
     {
-        ImGui::TreeNodeEx(TCHAR_TO_ANSI(*PropertyName), ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen | ImGuiTreeNodeFlags_SpanFullWidth);
+        ImGui::TreeNodeEx(COG_TCHAR_TO_CHAR(*PropertyName), ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen | ImGuiTreeNodeFlags_SpanFullWidth);
     }
 
     //--------------------------------------------------------------------------------------
@@ -503,7 +504,7 @@ bool FCogEngineWindow_Inspector::RenderProperty(const FProperty* Property, uint8
             ImGui::TableNextColumn();
             ImGui::Text("Type:");
             ImGui::TableNextColumn();
-            ImGui::Text("%s", TCHAR_TO_ANSI(*Property->GetClass()->GetName()));
+            ImGui::Text("%s", COG_TCHAR_TO_CHAR(*Property->GetClass()->GetName()));
 
 #if WITH_EDITORONLY_DATA
             ImGui::TableNextRow();
@@ -517,7 +518,7 @@ bool FCogEngineWindow_Inspector::RenderProperty(const FProperty* Property, uint8
             ImGui::TableNextColumn();
             ImGui::Text("FullName:");
             ImGui::TableNextColumn();
-            ImGui::Text("%s", TCHAR_TO_ANSI(*Property->GetFullName()));
+            ImGui::Text("%s", COG_TCHAR_TO_CHAR(*Property->GetFullName()));
 
             ImGui::TableNextRow();
             ImGui::TableNextColumn();
@@ -655,7 +656,7 @@ bool FCogEngineWindow_Inspector::RenderProperty(const FProperty* Property, uint8
     else
     {
         ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(255, 0, 0, 128));
-        ImGui::Text("Unmanaged Type: %s", TCHAR_TO_ANSI(*Property->GetClass()->GetName()));
+        ImGui::Text("Unmanaged Type: %s", COG_TCHAR_TO_CHAR(*Property->GetClass()->GetName()));
         ImGui::PopStyleColor();
     }
 
@@ -815,7 +816,7 @@ bool FCogEngineWindow_Inspector::RenderName(const FNameProperty* NameProperty, u
     FString NameValue;
     NameProperty->ExportTextItem_Direct(NameValue, PointerToValue, nullptr, nullptr, PPF_None, nullptr);
     ImGui::BeginDisabled();
-    ImGui::Text("%s", TCHAR_TO_ANSI(*NameValue));
+    ImGui::Text("%s", COG_TCHAR_TO_CHAR(*NameValue));
     ImGui::EndDisabled();
 
     return false;
@@ -846,7 +847,7 @@ bool FCogEngineWindow_Inspector::RenderObject(UObject* Object, bool ShowChildren
     }
 
     ImGui::BeginDisabled();
-    ImGui::Text("%s", TCHAR_TO_ANSI(*Object->GetClass()->GetName()));
+    ImGui::Text("%s", COG_TCHAR_TO_CHAR(*Object->GetClass()->GetName()));
     ImGui::EndDisabled();
 
     ImGui::SameLine();
@@ -877,7 +878,7 @@ bool FCogEngineWindow_Inspector::RenderObject(UObject* Object, bool ShowChildren
 bool FCogEngineWindow_Inspector::RenderStruct(const FStructProperty* StructProperty, uint8* PointerToValue, bool ShowChildren)
 {
     ImGui::BeginDisabled();
-    ImGui::Text("%s", TCHAR_TO_ANSI(*StructProperty->Struct->GetStructCPPName()));
+    ImGui::Text("%s", COG_TCHAR_TO_CHAR(*StructProperty->Struct->GetStructCPPName()));
     ImGui::EndDisabled();
 
     bool HasChanged = false;
@@ -910,7 +911,7 @@ bool FCogEngineWindow_Inspector::RenderClass(const FClassProperty* ClassProperty
     else
     {
         ImGui::BeginDisabled();
-        ImGui::Text("%s", TCHAR_TO_ANSI(*ClassProperty->MetaClass->GetName()));
+        ImGui::Text("%s", COG_TCHAR_TO_CHAR(*ClassProperty->MetaClass->GetName()));
         ImGui::EndDisabled();
     }
 
@@ -930,7 +931,7 @@ bool FCogEngineWindow_Inspector::RenderInterface(const FInterfaceProperty* Inter
     else
     {
         ImGui::BeginDisabled();
-        ImGui::Text("%s", TCHAR_TO_ANSI(*Class->GetName()));
+        ImGui::Text("%s", COG_TCHAR_TO_CHAR(*Class->GetName()));
         ImGui::EndDisabled();
     }
 

--- a/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Metrics.cpp
+++ b/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Metrics.cpp
@@ -89,7 +89,7 @@ void FCogEngineWindow_Metrics::RenderContent()
         FName MetricName = Entry.Key;
         FCogDebugMetricEntry& Metric = Entry.Value;
 
-        if (ImGui::CollapsingHeader(TCHAR_TO_ANSI(*MetricName.ToString()), ImGuiTreeNodeFlags_DefaultOpen))
+        if (ImGui::CollapsingHeader(COG_TCHAR_TO_CHAR(*MetricName.ToString()), ImGuiTreeNodeFlags_DefaultOpen))
         {
             ImGui::PushID(Index);
             DrawMetric(Metric);
@@ -124,13 +124,13 @@ void FCogEngineWindow_Metrics::DrawMetric(FCogDebugMetricEntry& Metric)
 
     ImGui::Text("Crits");
     ImGui::SameLine(FCogWidgets::GetFontWidth() * 20);
-    FCogWidgets::ProgressBarCentered(Metric.Count == 0 ? 0.0f : Metric.Crits / static_cast<float>(Metric.Count), ImVec2(-1, 0), TCHAR_TO_ANSI(*FString::Printf(TEXT("%d / %d"), Metric.Crits, Metric.Count)));
+    FCogWidgets::ProgressBarCentered(Metric.Count == 0 ? 0.0f : Metric.Crits / static_cast<float>(Metric.Count), ImVec2(-1, 0), COG_TCHAR_TO_CHAR(*FString::Printf(TEXT("%d / %d"), Metric.Crits, Metric.Count)));
 
     if (FCogDebugMetric::MaxDurationSetting > 0.0f)
     {
         ImGui::Text("Timer");
         ImGui::SameLine(FCogWidgets::GetFontWidth() * 20);
-        FCogWidgets::ProgressBarCentered(Metric.Timer / (float)FCogDebugMetric::MaxDurationSetting, ImVec2(-1, 0), TCHAR_TO_ANSI(*FString::Printf(TEXT("%0.1f / %0.1f"), Metric.Timer, FCogDebugMetric::MaxDurationSetting)));
+        FCogWidgets::ProgressBarCentered(Metric.Timer / (float)FCogDebugMetric::MaxDurationSetting, ImVec2(-1, 0), COG_TCHAR_TO_CHAR(*FString::Printf(TEXT("%0.1f / %0.1f"), Metric.Timer, FCogDebugMetric::MaxDurationSetting)));
     }
     else
     {

--- a/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_NetEmulation.cpp
+++ b/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_NetEmulation.cpp
@@ -1,5 +1,6 @@
 #include "CogEngineWindow_NetEmulation.h"
 
+#include "CogCommon.h"
 #include "CogEngineWindow_Stats.h"
 #include "CogImguiHelper.h"
 #include "CogWidgets.h"
@@ -103,14 +104,14 @@ void FCogEngineWindow_NetEmulation::DrawControls()
     }
 
     FCogWidgets::SetNextItemToShortWidth();
-    if (ImGui::BeginCombo("Driver", TCHAR_TO_ANSI(*SelectedNetDriver->NetDriver->GetName())))
+    if (ImGui::BeginCombo("Driver", COG_TCHAR_TO_CHAR(*SelectedNetDriver->NetDriver->GetName())))
     {
         int i = 0;
         for (FNamedNetDriver& NamedNetDriver : WorldContext.ActiveNetDrivers)
         {
             if (NamedNetDriver.NetDriver != nullptr)
             {
-                if (ImGui::Selectable(TCHAR_TO_ANSI(*NamedNetDriver.NetDriver->GetName())))
+                if (ImGui::Selectable(COG_TCHAR_TO_CHAR(*NamedNetDriver.NetDriver->GetName())))
                 {
                     SelectedIndex = i;
                     SelectedNetDriver = &WorldContext.ActiveNetDrivers[i];

--- a/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Plots.cpp
+++ b/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Plots.cpp
@@ -1,5 +1,6 @@
 #include "CogEngineWindow_Plots.h"
 
+#include "CogCommon.h"
 #include "CogDebug.h"
 #include "CogDebugTracker.h"
 #include "CogImguiHelper.h"
@@ -220,7 +221,7 @@ void FCogEngineWindow_Plots::RenderEntryName(FCogDebugTracker& InTracker, const 
         }
     }
 
-    if (ImGui::Selectable(TCHAR_TO_ANSI(*Entry.Id.ToString()), IsAssignedToGraph, ImGuiSelectableFlags_AllowDoubleClick))
+    if (ImGui::Selectable(COG_TCHAR_TO_CHAR(*Entry.Id.ToString()), IsAssignedToGraph, ImGuiSelectableFlags_AllowDoubleClick))
     {
         if (IsAssignedToGraph)
         {
@@ -649,7 +650,7 @@ void FCogEngineWindow_Plots::RenderEvents(FCogDebugEventTrack& InTrack, const ch
             constexpr float Radius = 10.0f;
             PlotDrawList->AddNgon(PosMid, 10, Event.BorderColor, 4);
             PlotDrawList->AddNgonFilled(PosMid, 10, Event.FillColor, 4);
-            PlotDrawList->AddText(ImVec2(PosMid.x + 15, PosMid.y - 6), IM_COL32(255, 255, 255, 255), TCHAR_TO_ANSI(*Event.DisplayName));
+            PlotDrawList->AddText(ImVec2(PosMid.x + 15, PosMid.y - 6), IM_COL32(255, 255, 255, 255), COG_TCHAR_TO_CHAR(*Event.DisplayName));
 
             if ((Mouse.x > PosMid.x - Radius) && (Mouse.x < PosMid.x + Radius) && (Mouse.y > PosMid.y - Radius) && (Mouse.y < PosMid.y + Radius))
             {
@@ -665,7 +666,7 @@ void FCogEngineWindow_Plots::RenderEvents(FCogDebugEventTrack& InTrack, const ch
             PlotDrawList->AddRect(Min, Max, Event.BorderColor, 6.0f, Flags);
             PlotDrawList->AddRectFilled(Min, Max, Event.FillColor, 6.0f, Flags);
             PlotDrawList->PushClipRect(ImMax(Min, InPlotMin), ImMin(Max, InPlotMax));
-            PlotDrawList->AddText(ImVec2(PosMid.x + 5, PosMid.y - 7), IM_COL32(255, 255, 255, 255), TCHAR_TO_ANSI(*Event.DisplayName));
+            PlotDrawList->AddText(ImVec2(PosMid.x + 5, PosMid.y - 7), IM_COL32(255, 255, 255, 255), COG_TCHAR_TO_CHAR(*Event.DisplayName));
             PlotDrawList->PopClipRect();
 
             if (Mouse.x > Min.x && Mouse.x < Max.x && Mouse.y > Min.y && Mouse.y < Max.y)
@@ -706,7 +707,7 @@ void FCogEngineWindow_Plots::RenderEventTooltip(const FCogDebugEvent* HoveredEve
                 ImGui::TableNextColumn();
                 ImGui::Text("Name");
                 ImGui::TableNextColumn();
-                ImGui::Text("%s", TCHAR_TO_ANSI(*HoveredEvent->DisplayName));
+                ImGui::Text("%s", COG_TCHAR_TO_CHAR(*HoveredEvent->DisplayName));
 
                 //------------------------
                 // Owner Name
@@ -715,7 +716,7 @@ void FCogEngineWindow_Plots::RenderEventTooltip(const FCogDebugEvent* HoveredEve
                 ImGui::TableNextColumn();
                 ImGui::Text("Owner");
                 ImGui::TableNextColumn();
-                ImGui::Text("%s", TCHAR_TO_ANSI(*HoveredEvent->OwnerName));
+                ImGui::Text("%s", COG_TCHAR_TO_CHAR(*HoveredEvent->OwnerName));
 
                 //------------------------
                 // Times
@@ -756,9 +757,9 @@ void FCogEngineWindow_Plots::RenderEventTooltip(const FCogDebugEvent* HoveredEve
                 {
                     ImGui::TableNextRow();
                     ImGui::TableNextColumn();
-                    ImGui::Text("%s", TCHAR_TO_ANSI(*Param.Name.ToString()));
+                    ImGui::Text("%s", COG_TCHAR_TO_CHAR(*Param.Name.ToString()));
                     ImGui::TableNextColumn();
-                    ImGui::Text("%s", TCHAR_TO_ANSI(*Param.Value));
+                    ImGui::Text("%s", COG_TCHAR_TO_CHAR(*Param.Value));
                 }
                 ImGui::EndTable();
             }

--- a/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Scalability.cpp
+++ b/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Scalability.cpp
@@ -1,5 +1,6 @@
 #include "CogEngineWindow_Scalability.h"
 
+#include "CogCommon.h"
 #include "imgui.h"
 #include "CogWidgets.h"
 #include "Engine/Engine.h"
@@ -23,18 +24,18 @@ void FCogEngineWindow_Scalability::RenderContent()
     Scalability::FQualityLevels Levels = Scalability::GetQualityLevels();
     const FString CurrentQualityName = Scalability::GetQualityLevelText(Levels.GetMinQualityLevel(), SCALABILITY_NUM_LEVELS).ToString();
     FCogWidgets::SetNextItemToShortWidth();
-    if (ImGui::BeginCombo("Scalability", TCHAR_TO_ANSI(*CurrentQualityName)))
+    if (ImGui::BeginCombo("Scalability", COG_TCHAR_TO_CHAR(*CurrentQualityName)))
     {
         for (int32 i = 0; i < SCALABILITY_NUM_LEVELS; ++i)
         {
             FString QualityName = Scalability::GetQualityLevelText(i, SCALABILITY_NUM_LEVELS).ToString();
-            if (ImGui::Selectable(TCHAR_TO_ANSI(*QualityName)))
+            if (ImGui::Selectable(COG_TCHAR_TO_CHAR(*QualityName)))
             {
                 Levels.SetFromSingleQualityLevel(i);
                 Scalability::SetQualityLevels(Levels);
 
                 ImGui::LogToClipboard();
-                ImGui::LogText("%s", TCHAR_TO_ANSI(*FString::Printf(TEXT("Setting Quality Level to %s"), *QualityName)));
+                ImGui::LogText("%s", COG_TCHAR_TO_CHAR(*FString::Printf(TEXT("Setting Quality Level to %s"), *QualityName)));
                 ImGui::LogFinish();
             }
         }

--- a/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Slate.cpp
+++ b/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Slate.cpp
@@ -1,5 +1,6 @@
 #include "CogEngineWindow_Slate.h"
 
+#include "CogCommon.h"
 #include "CogImguiHelper.h"
 #include "Framework/Application/SlateApplication.h"
 #include "Framework/Application/SlateUser.h"
@@ -29,11 +30,11 @@ void FCogEngineWindow_Slate::RenderContent()
     static int32 SelectedUserIndex = 0;
 
     ImGui::SetNextItemWidth(-1);
-    if (ImGui::BeginCombo("##User", TCHAR_TO_ANSI(*FString::Printf(TEXT("%d"), SelectedUserIndex))))
+    if (ImGui::BeginCombo("##User", COG_TCHAR_TO_CHAR(*FString::Printf(TEXT("%d"), SelectedUserIndex))))
     {
         SlateApp.ForEachUser([this](const FSlateUser& User)
         {
-            if (ImGui::Selectable(TCHAR_TO_ANSI(*FString::Printf(TEXT("%d"), SelectedUserIndex)), false))
+            if (ImGui::Selectable(COG_TCHAR_TO_CHAR(*FString::Printf(TEXT("%d"), SelectedUserIndex)), false))
             {
                 SelectedUserIndex = User.GetUserIndex();
             }
@@ -72,7 +73,7 @@ void FCogEngineWindow_Slate::RenderUser(FSlateUser& User)
         {
             FocusedWidgetText = FocusedWidget->ToString();
         }
-        ImGui::Text("%s", TCHAR_TO_ANSI(*FocusedWidgetText));
+        ImGui::Text("%s", COG_TCHAR_TO_CHAR(*FocusedWidgetText));
 
         //------------------------
         // Cursor Captor
@@ -86,7 +87,7 @@ void FCogEngineWindow_Slate::RenderUser(FSlateUser& User)
         {
             CursorCaptorWidgetText = CursorCaptorWidget->ToString();
         }
-        ImGui::Text("%s", TCHAR_TO_ANSI(*CursorCaptorWidgetText));
+        ImGui::Text("%s", COG_TCHAR_TO_CHAR(*CursorCaptorWidgetText));
 
         //------------------------
         // Cursor Position

--- a/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Spawns.cpp
+++ b/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Spawns.cpp
@@ -1,5 +1,6 @@
 #include "CogEngineWindow_Spawns.h"
 
+#include "CogCommon.h"
 #include "CogEngineDataAsset.h"
 #include "CogEngineReplicator.h"
 #include "CogImguiHelper.h"
@@ -11,7 +12,7 @@ void FCogEngineWindow_Spawns::RenderHelp()
     ImGui::Text(
         "This window can be used to spawn new actors in the world. "
         "The spawn list can be configured in the '%s' data asset. "
-        , TCHAR_TO_ANSI(*GetNameSafe(Asset.Get()))
+        , COG_TCHAR_TO_CHAR(*GetNameSafe(Asset.Get()))
     );
 }
 
@@ -58,7 +59,7 @@ void FCogEngineWindow_Spawns::RenderContent()
 //--------------------------------------------------------------------------------------------------------------------------
 void FCogEngineWindow_Spawns::RenderSpawnGroup(ACogEngineReplicator& Replicator, const FCogEngineSpawnGroup& SpawnGroup, int32 GroupIndex)
 {
-    if (FCogWidgets::DarkCollapsingHeader(TCHAR_TO_ANSI(*SpawnGroup.Name), ImGuiTreeNodeFlags_DefaultOpen))
+    if (FCogWidgets::DarkCollapsingHeader(COG_TCHAR_TO_CHAR(*SpawnGroup.Name), ImGuiTreeNodeFlags_DefaultOpen))
     {
         ImGui::PushID(GroupIndex);
 
@@ -108,7 +109,7 @@ bool FCogEngineWindow_Spawns::RenderSpawnAsset(ACogEngineReplicator& Replicator,
         EntryName = GetNameSafe(SpawnEntry.Class);
     }
 
-    if (ImGui::Button(TCHAR_TO_ANSI(*EntryName), ImVec2(-1, 0)))
+    if (ImGui::Button(COG_TCHAR_TO_CHAR(*EntryName), ImVec2(-1, 0)))
     {
         IsPressed = true;
         Replicator.Server_Spawn(SpawnEntry);

--- a/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Stats.cpp
+++ b/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Stats.cpp
@@ -1,5 +1,6 @@
 #include "CogEngineWindow_Stats.h"
 
+#include "CogCommon.h"
 #include "CogImguiHelper.h"
 #include "CogWidgets.h"
 #include "Engine/Engine.h"
@@ -97,7 +98,7 @@ void FCogEngineWindow_Stats::RenderMainMenuWidgetFrameRate()
     const int32 Fps = static_cast<int32>(GAverageFPS);
 
     ImGui::PushStyleColor(ImGuiCol_Text, Config->GetFpsColor(Fps));
-    const bool Open = ImGui::BeginMenu(TCHAR_TO_ANSI(*FString::Printf(TEXT("%3dfps###FrameRateButton"), Fps)));
+    const bool Open = ImGui::BeginMenu(COG_TCHAR_TO_CHAR(*FString::Printf(TEXT("%3dfps###FrameRateButton"), Fps)));
     const float Width = ImGui::GetItemRectSize().x;
     ImGui::PopStyleColor(1);
 
@@ -144,7 +145,7 @@ void FCogEngineWindow_Stats::RenderMainMenuWidgetPing()
 
     const int32 Ping = static_cast<int32>(PlayerState->GetPingInMilliseconds());
     ImGui::PushStyleColor(ImGuiCol_Text, Config->GetPingColor(Ping));
-    const bool Open = ImGui::BeginMenu(TCHAR_TO_ANSI(*FString::Printf(TEXT("%3dms###PingButton"), Ping)));
+    const bool Open = ImGui::BeginMenu(COG_TCHAR_TO_CHAR(*FString::Printf(TEXT("%3dms###PingButton"), Ping)));
     const float Width = ImGui::GetItemRectSize().x;
     ImGui::PopStyleColor(1);
     
@@ -202,7 +203,7 @@ void FCogEngineWindow_Stats::RenderMainMenuWidgetPacketLoss()
     const float TotalPacketLost = (OutPacketLost + InPacketLost) / 2;
 
     ImGui::PushStyleColor(ImGuiCol_Text, Config->GetPacketLossColor(TotalPacketLost));
-    const bool Open = ImGui::BeginMenu(TCHAR_TO_ANSI(*FString::Printf(TEXT("%2d%% ###PacketLossButton"), static_cast<int32>(TotalPacketLost))));
+    const bool Open = ImGui::BeginMenu(COG_TCHAR_TO_CHAR(*FString::Printf(TEXT("%2d%% ###PacketLossButton"), static_cast<int32>(TotalPacketLost))));
     const float Width = ImGui::GetItemRectSize().x;
     ImGui::PopStyleColor(1);
 

--- a/Plugins/Cog/Source/CogEngine/Public/CogEngineCollisionTester.h
+++ b/Plugins/Cog/Source/CogEngine/Public/CogEngineCollisionTester.h
@@ -66,78 +66,78 @@ public:
 
     void Query() const;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     bool TickInEditor = false;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     ECogEngine_CollisionQueryType Type = ECogEngine_CollisionQueryType::LineTrace;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     ECogEngine_CollisionQueryTraceMode TraceMode = ECogEngine_CollisionQueryTraceMode::Multi;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     ECogEngine_CollisionQueryOverlapMode OverlapMode = ECogEngine_CollisionQueryOverlapMode::Multi;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     ECogEngine_CollisionQueryBy By = ECogEngine_CollisionQueryBy::Channel;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     ECogEngine_CollisionQueryShape Shape = ECogEngine_CollisionQueryShape::Sphere;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     bool TraceComplex = false;
 
     UPROPERTY()
     int32 ObjectTypesToQuery = 0;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     TEnumAsByte<ECollisionChannel> TraceChannel = ECC_Visibility;
 
     UPROPERTY()
     int32 ProfileIndex = 0;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     FVector ShapeExtent = FVector(100, 100, 100);
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     bool DrawHitLocations = true;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     bool DrawHitImpactPoints = true;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     bool DrawHitShapes = true;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     bool DrawHitNormals = true;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     bool DrawHitImpactNormals = true;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     bool DrawHitPrimitives = true;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     bool DrawHitActorsNames = false;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     float HitPointSize = 5.0f;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     FColor NoHitColor = FColor::Red;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     FColor HitColor = FColor::Green;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     FColor NormalColor = FColor::Yellow;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     FColor ImpactNormalColor = FColor::Cyan;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     TObjectPtr<USceneComponent> StartComponent;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     TObjectPtr<USceneComponent> EndComponent;
 };

--- a/Plugins/Cog/Source/CogEngine/Public/CogEngineDataAsset.h
+++ b/Plugins/Cog/Source/CogEngine/Public/CogEngineDataAsset.h
@@ -42,13 +42,13 @@ struct COGENGINE_API FCogEngineCheat
 {
     GENERATED_BODY()
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     FString Name;
 
-    UPROPERTY(EditAnywhere, Instanced)
+    UPROPERTY(EditAnywhere, Instanced, Category = "Cog")
     TObjectPtr<UCogEngineCheat_Execution> Execution;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     FLinearColor Color = FLinearColor::White;
 
     mutable FLinearColor CustomColor = FLinearColor::White;
@@ -76,10 +76,10 @@ struct COGENGINE_API FCogEngineSpawnEntry
 {
     GENERATED_BODY()
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     TSubclassOf<AActor> Class;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     TObjectPtr<const UObject> Asset = nullptr;
 };
 
@@ -89,13 +89,13 @@ struct COGENGINE_API FCogEngineSpawnGroup
 {
     GENERATED_BODY()
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     FString Name;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     FLinearColor Color = FLinearColor(0.5f, 0.5f, 0.5f, 1.0f);
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     TArray<FCogEngineSpawnEntry> Spawns;
 };
 
@@ -106,7 +106,7 @@ class COGENGINE_API UCogEngineDataAsset : public UPrimaryDataAsset
     GENERATED_BODY()
 
 public:
-    
+
     UCogEngineDataAsset() {}
 
     UPROPERTY(Category = "Cheats", EditAnywhere, meta = (TitleProperty = "Name"))
@@ -117,7 +117,7 @@ public:
 
     UPROPERTY(Category = "Selection", EditAnywhere)
     TArray<TSubclassOf<AActor>> SelectionFilters = { ACharacter::StaticClass(), AActor::StaticClass(), AGameModeBase::StaticClass(), AGameStateBase::StaticClass() };
-    
+
     UPROPERTY(Category = "Selection", EditAnywhere)
     TEnumAsByte<ETraceTypeQuery> SelectionTraceChannel = UEngineTypes::ConvertToTraceType(ECC_Pawn);
 };

--- a/Plugins/Cog/Source/CogImgui/CogImgui.Build.cs
+++ b/Plugins/Cog/Source/CogImgui/CogImgui.Build.cs
@@ -13,6 +13,7 @@ public class CogImgui : ModuleRules
             "ImGui",
             "ImPlot",
             "NetImgui",
+			"CogCommon",
         });
 
         PrivateDependencyModuleNames.AddRange(new[]

--- a/Plugins/CogAbility/Source/CogAbility/Private/CogAbilityWindow_Abilities.cpp
+++ b/Plugins/CogAbility/Source/CogAbility/Private/CogAbilityWindow_Abilities.cpp
@@ -5,6 +5,7 @@
 #include "CogAbilityDataAsset.h"
 #include "CogAbilityHelper.h"
 #include "CogAbilityReplicator.h"
+#include "CogCommon.h"
 #include "CogImguiHelper.h"
 #include "CogWidgets.h"
 #include "CogDebugRob.h"
@@ -87,7 +88,7 @@ void FCogAbilityWindow_Abilities::RenderOpenAbilities()
         }
 
         bool Open = true;
-        if (ImGui::Begin(TCHAR_TO_ANSI(*GetAbilityName(Ability)), &Open))
+        if (ImGui::Begin(COG_TCHAR_TO_CHAR(*GetAbilityName(Ability)), &Open))
         {
             RenderAbilityInfo(*AbilitySystemComponent, *Spec);
             ImGui::End();
@@ -140,7 +141,7 @@ void FCogAbilityWindow_Abilities::RenderAbilitiesMenu(AActor* Selection)
                     {
                         ImGui::PushID(Index);
 
-                        if (ImGui::MenuItem(TCHAR_TO_ANSI(*GetNameSafe(AbilityClass))))
+                        if (ImGui::MenuItem(COG_TCHAR_TO_CHAR(*GetNameSafe(AbilityClass))))
                         {
                             if (ACogAbilityReplicator* Replicator = ACogAbilityReplicator::GetFirstReplicator(*GetWorld()))
                             {
@@ -222,7 +223,7 @@ void FCogAbilityWindow_Abilities::RenderAbilitiesTableAbilityName(UAbilitySystem
     const ImVec4 Color = GetAbilityColor(AbilitySystemComponent, Spec);
     ImGui::PushStyleColor(ImGuiCol_Text, Color);
 
-    if (ImGui::Selectable(TCHAR_TO_ANSI(*GetAbilityName(Ability)), SelectedIndex == Index, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_AllowOverlap | ImGuiSelectableFlags_AllowDoubleClick))
+    if (ImGui::Selectable(COG_TCHAR_TO_CHAR(*GetAbilityName(Ability)), SelectedIndex == Index, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_AllowOverlap | ImGuiSelectableFlags_AllowDoubleClick))
     {
         SelectedIndex = Index;
                 
@@ -454,7 +455,7 @@ void FCogAbilityWindow_Abilities::RenderAbilityCooldown(const UAbilitySystemComp
     {
         ImGui::PushStyleColor(ImGuiCol_PlotHistogram, IM_COL32(100, 100, 100, 255));
         ImGui::PushStyleColor(ImGuiCol_FrameBg, IM_COL32(0, 0, 0, 100));
-        ImGui::ProgressBar(RemainingTime / CooldownDuration, ImVec2(-1, ImGui::GetTextLineHeightWithSpacing() * 0.8f), TCHAR_TO_ANSI(*FString::Printf(TEXT("%.2f / %.2f"), RemainingTime, CooldownDuration)));
+        ImGui::ProgressBar(RemainingTime / CooldownDuration, ImVec2(-1, ImGui::GetTextLineHeightWithSpacing() * 0.8f), COG_TCHAR_TO_CHAR(*FString::Printf(TEXT("%.2f / %.2f"), RemainingTime, CooldownDuration)));
         ImGui::PopStyleColor(2);
     }
 }
@@ -566,7 +567,7 @@ void FCogAbilityWindow_Abilities::RenderAbilityInfo(const UAbilitySystemComponen
         ImGui::TextColored(TextColor, "Name");
         ImGui::TableNextColumn();
         ImGui::PushStyleColor(ImGuiCol_Text, Color);
-        ImGui::Text("%s", TCHAR_TO_ANSI(*GetAbilityName(Ability)));
+        ImGui::Text("%s", COG_TCHAR_TO_CHAR(*GetAbilityName(Ability)));
         ImGui::PopStyleColor(1);
 
         //------------------------
@@ -609,7 +610,7 @@ void FCogAbilityWindow_Abilities::RenderAbilityInfo(const UAbilitySystemComponen
         ImGui::TableNextColumn();
         ImGui::TextColored(TextColor, "Handle");
         ImGui::TableNextColumn();
-        ImGui::Text("%s", TCHAR_TO_ANSI(*Spec.Handle.ToString()));
+        ImGui::Text("%s", COG_TCHAR_TO_CHAR(*Spec.Handle.ToString()));
 
         //------------------------
         // Level

--- a/Plugins/CogAbility/Source/CogAbility/Private/CogAbilityWindow_Attributes.cpp
+++ b/Plugins/CogAbility/Source/CogAbility/Private/CogAbilityWindow_Attributes.cpp
@@ -9,6 +9,7 @@
 #include "CogWidgets.h"
 #include "AttributeSet.h"
 #include "CogAbilityWindow_Abilities.h"
+#include "CogCommon.h"
 #include "imgui_internal.h"
 
 //--------------------------------------------------------------------------------------------------------------------------
@@ -149,7 +150,7 @@ void FCogAbilityWindow_Attributes::RenderContent()
             if (AttributeSet == nullptr)
             { continue; }
 
-            ImGui::PushID(TCHAR_TO_ANSI(*AttributeSet->GetName()));
+            ImGui::PushID(COG_TCHAR_TO_CHAR(*AttributeSet->GetName()));
 
             FString AttributeSetName = AttributeSet->GetName();
             FormatAttributeSetName(AttributeSetName);
@@ -232,7 +233,7 @@ void FCogAbilityWindow_Attributes::RenderContent()
                         ImGui::TableNextRow();
                         ImGui::TableNextColumn();
                         ImGui::PushStyleColor(ImGuiCol_Text, FCogImguiHelper::ToImVec4(Config->CategoryColor));
-                        bOpenCategory = ImGui::TreeNodeEx(TCHAR_TO_ANSI(*It.Key), ImGuiTreeNodeFlags_SpanFullWidth | ImGuiTreeNodeFlags_SpanAllColumns | ImGuiTreeNodeFlags_LabelSpanAllColumns);
+                        bOpenCategory = ImGui::TreeNodeEx(COG_TCHAR_TO_CHAR(*It.Key), ImGuiTreeNodeFlags_SpanFullWidth | ImGuiTreeNodeFlags_SpanAllColumns | ImGuiTreeNodeFlags_LabelSpanAllColumns);
                         ImGui::PopStyleColor();
                     }
 
@@ -400,7 +401,7 @@ void FCogAbilityWindow_Attributes::RenderAttributeDetails(const UAbilitySystemCo
         ImGui::TableNextColumn();
         ImGui::TextColored(TextColor, "Name");
         ImGui::TableNextColumn();
-        ImGui::Text("%s", TCHAR_TO_ANSI(*Attribute.GetName()));
+        ImGui::Text("%s", COG_TCHAR_TO_CHAR(*Attribute.GetName()));
 
         //------------------------
         // Base Value
@@ -462,13 +463,13 @@ void FCogAbilityWindow_Attributes::RenderAttributeDetails(const UAbilitySystemCo
                         ImGui::TableNextColumn();
                         ImGui::TextColored(TextColor, "Effect");
                         ImGui::TableNextColumn();
-                        ImGui::Text("%s", TCHAR_TO_ANSI(*FCogAbilityHelper::CleanupName(GetNameSafe(ActiveEffect->Spec.Def))));
+                        ImGui::Text("%s", COG_TCHAR_TO_CHAR(*FCogAbilityHelper::CleanupName(GetNameSafe(ActiveEffect->Spec.Def))));
 
                         ImGui::TableNextRow();
                         ImGui::TableNextColumn();
                         ImGui::TextColored(TextColor, "Operation");
                         ImGui::TableNextColumn();
-                        ImGui::Text("%s", TCHAR_TO_ANSI(*EGameplayModOpToString(ModInfo.ModifierOp)));
+                        ImGui::Text("%s", COG_TCHAR_TO_CHAR(*EGameplayModOpToString(ModInfo.ModifierOp)));
 
                         ImGui::TableNextRow();
                         ImGui::TableNextColumn();

--- a/Plugins/CogAbility/Source/CogAbility/Public/CogAbilityCheat_Execution_ActivateAbility.h
+++ b/Plugins/CogAbility/Source/CogAbility/Public/CogAbilityCheat_Execution_ActivateAbility.h
@@ -19,9 +19,9 @@ public:
 
     virtual bool GetColor(const FCogWindow& InCallingWindow, FLinearColor& OutColor) const override;
 
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "Cog")
     TSubclassOf<UGameplayAbility> Ability;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     bool RemoveAbilityOnEnd = true;
 };

--- a/Plugins/CogAbility/Source/CogAbility/Public/CogAbilityCheat_Execution_ApplyEffect.h
+++ b/Plugins/CogAbility/Source/CogAbility/Public/CogAbilityCheat_Execution_ApplyEffect.h
@@ -19,6 +19,6 @@ public:
 
     virtual bool GetColor(const FCogWindow& InCallingWindow, FLinearColor& OutColor) const override;
 
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "Cog")
     TSubclassOf<UGameplayEffect> Effect;
 };

--- a/Plugins/CogAbility/Source/CogAbility/Public/CogAbilityDataAsset.h
+++ b/Plugins/CogAbility/Source/CogAbility/Public/CogAbilityDataAsset.h
@@ -14,10 +14,10 @@ struct COGABILITY_API FCogAbilityCheat
 {
     GENERATED_BODY()
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     FString Name;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     TSubclassOf<UGameplayEffect> Effect;
 };
 
@@ -27,25 +27,25 @@ struct COGABILITY_API FCogAbilityPool
 {
     GENERATED_BODY()
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     FString Name;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     FGameplayAttribute Value;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     FGameplayAttribute Min;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     FGameplayAttribute Max;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     FGameplayAttribute Regen;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     FLinearColor Color = FLinearColor(0.5f, 0.5f, 0.5f, 1.0f);
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     FLinearColor BackColor = FLinearColor(0.15, 0.15, 0.15, 1.0f);
 };
 
@@ -56,16 +56,16 @@ struct FCogAbilityTweak
 {
     GENERATED_BODY()
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     FName Name;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     TSubclassOf<UGameplayEffect> Effect;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     float Multiplier = 0.01f;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     float AddPostMultiplier = 1.0f;
 };
 
@@ -75,22 +75,22 @@ struct FCogAbilityTweakCategory
 {
     GENERATED_BODY()
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     FString Name;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     FGameplayTag Id;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     TSubclassOf<AActor> ActorClass;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     FGameplayTagContainer RequiredTags;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     FGameplayTagContainer IgnoredTags;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     FLinearColor Color = FLinearColor::White;
 };
 
@@ -100,13 +100,13 @@ struct FCogAbilityTweakProfileValue
 {
     GENERATED_BODY()
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     TSubclassOf<UGameplayEffect> Effect;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     FGameplayTag CategoryId;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     float Value = 0.0f;
 };
 
@@ -116,10 +116,10 @@ struct FCogAbilityTweakProfile
 {
     GENERATED_BODY()
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     FName Name;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Cog")
     TArray<FCogAbilityTweakProfileValue> Tweaks;
 };
 
@@ -131,7 +131,7 @@ class COGABILITY_API UCogAbilityDataAsset : public UPrimaryDataAsset
     GENERATED_BODY()
 
 public:
-    
+
     UCogAbilityDataAsset() {}
 
     //----------------------------------------------------------------------------------------------------------------------
@@ -147,16 +147,16 @@ public:
 
     UPROPERTY(Category="Cheats", EditAnywhere)
     FGameplayTag NegativeEffectTag;
-    
+
     UPROPERTY(Category = "Cheats", EditAnywhere)
     FGameplayTag PositiveEffectTag;
 
     UPROPERTY(Category="Cheats", EditAnywhere)
     FGameplayTag NegativeAbilityTag;
-    
+
     UPROPERTY(Category = "Cheats", EditAnywhere)
     FGameplayTag PositiveAbilityTag;
-    
+
     UPROPERTY(Category = "Cheats", EditAnywhere, meta = (TitleProperty = "Name"))
     TArray<FCogAbilityCheat> PersistentEffects;
 


### PR DESCRIPTION
unreal engine require category meta, and now, cog plugins can be placed in engine/plugins for multi project use

Adds the "Cog" category to various properties in CogCommonLog, CogEngineCollisionTester, CogEngineDataAsset, CogAbilityCheat_Execution_ActivateAbility, CogAbilityCheat_Execution_ApplyEffect and CogAbilityDataAsset for better organization.