### PR TITLE
[fix] InputWindow Action and Gamepad compatibility with UE 5.6

### DIFF
--- a/Plugins/CogInput/Source/CogInput/Private/CogInputWindow_Actions.cpp
+++ b/Plugins/CogInput/Source/CogInput/Private/CogInputWindow_Actions.cpp
@@ -8,6 +8,7 @@
 #include "imgui_internal.h"
 #include "InputAction.h"
 #include "InputMappingContext.h"
+#include "Misc/EngineVersionComparison.h"
 #include "Styling/SlateTypes.h"
 
 //--------------------------------------------------------------------------------------------------------------------------
@@ -89,7 +90,12 @@ void FCogInputWindow_Actions::RenderContent()
         {
             FCogInputMappingContextInfo& MappingInfo = AllAppliedMappings.AddDefaulted_GetRef();
             MappingInfo.MappingContext = kv.Key;
+
+#if UE_VERSION_OLDER_THAN(5, 6, 0)
+            MappingInfo.Priority = kv.Value;
+#else //UE_VERSION_OLDER_THAN(5, 6, 0)
             MappingInfo.AppliedInputContextData = kv.Value;
+#endif //UE_VERSION_OLDER_THAN(5, 6, 0)
         }
     }
 
@@ -128,7 +134,12 @@ void FCogInputWindow_Actions::RenderContent()
 		//----------------------------------------------------
         FCogInputMappingContextInfo& NewMappingInfo = Mappings.AddDefaulted_GetRef();
         NewMappingInfo.MappingContext = MappingInfo.MappingContext;
+
+#if UE_VERSION_OLDER_THAN(5, 6, 0)
+        MappingInfo.Priority = MappingInfo.Priority;
+#else
         NewMappingInfo.AppliedInputContextData = MappingInfo.AppliedInputContextData;
+#endif
 
         //----------------------------------------------------
 		// Add all the mapping actions
@@ -157,7 +168,11 @@ void FCogInputWindow_Actions::RenderContent()
 
         Mappings.Sort([](const FCogInputMappingContextInfo& Lhs, const FCogInputMappingContextInfo& Rhs)
             {
+#if UE_VERSION_OLDER_THAN(5, 6, 0)
+                return Lhs.Priority < Rhs.Priority;
+#else
                 return Lhs.AppliedInputContextData.Priority < Rhs.AppliedInputContextData.Priority;
+#endif
             });
     }
 

--- a/Plugins/CogInput/Source/CogInput/Public/CogInputActionInfo.h
+++ b/Plugins/CogInput/Source/CogInput/Public/CogInputActionInfo.h
@@ -3,13 +3,25 @@
 #include "CoreMinimal.h"
 #include "CogDebugRob.h"
 #include "EnhancedPlayerInput.h"
+#include "Misc/EngineVersionComparison.h"
 
 class UInputAction;
 class UInputMappingContext;
 class UEnhancedInputLocalPlayerSubsystem;
 
+#if UE_VERSION_OLDER_THAN(5, 6, 0)
+
+typedef TMap<TObjectPtr<const UInputMappingContext>, int32> CogInputMappingContextMap;
+DEFINE_PRIVATE_ACCESSOR_VARIABLE(UEnhancedPlayerInput_AppliedInputContexts, UEnhancedPlayerInput, CogInputMappingContextMap, AppliedInputContexts);
+
+#else //UE_VERSION_OLDER_THAN(5, 6, 0)
+
 typedef TMap<TObjectPtr<const UInputMappingContext>, FAppliedInputContextData>  CogInputMappingContextMap;
 DEFINE_PRIVATE_ACCESSOR_VARIABLE(UEnhancedPlayerInput_AppliedInputContexts, UEnhancedPlayerInput, CogInputMappingContextMap, AppliedInputContextData);
+
+#endif //UE_VERSION_OLDER_THAN(5, 6, 0)
+
+
 
 struct FCogInputActionInfo
 {
@@ -47,7 +59,11 @@ struct FCogInputMappingContextInfo
 {
     TObjectPtr<const UInputMappingContext> MappingContext;
 
-	FAppliedInputContextData AppliedInputContextData;
+#if UE_VERSION_OLDER_THAN(5, 6, 0)
+    int32 Priority = 0;
+#else //UE_VERSION_OLDER_THAN(5, 6, 0)
+    FAppliedInputContextData AppliedInputContextData;
+#endif //UE_VERSION_OLDER_THAN(5, 6, 0)
 
     TArray<FCogInputActionInfo> Actions;
 };


### PR DESCRIPTION
The variable `AppliedInputContexts` in UEnhancedPlayerInput is deprecated in UE 5.6.
I switched to `AppliedInputContextData` in **CogInputActionInfo.h** and updated **CogInputWindow_Actions.cpp** accordingly.

Tested on **UE 5.6**
This fix may not be backward-compatible with earlier UE versions (<5.6). 