### PR TITLE
Set bUseCustomContextMenu to true in FCogEngineWindow_Skeleton

### DIFF
--- a/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Skeleton.cpp
+++ b/Plugins/Cog/Source/CogEngine/Private/CogEngineWindow_Skeleton.cpp
@@ -14,6 +14,7 @@ void FCogEngineWindow_Skeleton::Initialize()
     Super::Initialize();
 
     bHasMenu = true;
+    bUseCustomContextMenu = true;
 }
 
 //--------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Without this set, the context menu specific to the skeleton window in inaccessible while the skeleton is popped out.
Uses same pattern as FCogInputWindow_Gamepad.