### PR TITLE
Set HasChanged in FCogWidgets::ComboboxEnum overload

### DIFF
--- a/Plugins/Cog/Source/Cog/Private/CogWidgets.cpp
+++ b/Plugins/Cog/Source/Cog/Private/CogWidgets.cpp
@@ -408,6 +408,7 @@ bool FCogWidgets::ComboboxEnum(const char* Label, const FEnumProperty* EnumPrope
     if (ComboboxEnum(Label, Enum, EnumValue, NewValue))
     {
         EnumProperty->GetUnderlyingProperty()->SetIntPropertyValue(PointerToValue, NewValue);
+        HasChanged = true;
     }
 
     return HasChanged;


### PR DESCRIPTION
Setting the returned HasChanged bool in overload of FCogWidgets::ComboboxEnum